### PR TITLE
mod(atomo): se eliminó la restricción de valoración en el rango [0,1]

### DIFF
--- a/src/Solver/Atomo.cs
+++ b/src/Solver/Atomo.cs
@@ -4,14 +4,11 @@
     {
         internal Atomo(int posicion, decimal valoracion)
         {
-            if (posicion <= 0)
+            if (posicion < 1)
                 throw new ArgumentException($"La posición debe ser positiva: {posicion}", nameof(posicion));
 
             if (valoracion < 0)
                 throw new ArgumentException($"La valoración no puede ser negativa: {valoracion}", nameof(valoracion));
-
-            if (valoracion > 1)
-                throw new ArgumentException($"La valoración no puede ser mayor que 1: {valoracion}", nameof(valoracion));
 
             Posicion = posicion;
             Valoracion = valoracion;

--- a/tests/Solver.Tests/AtomoTests.cs
+++ b/tests/Solver.Tests/AtomoTests.cs
@@ -20,14 +20,6 @@
         }
 
         [Fact]
-        public void Constructor_Valoracion_NoPuedeSerMayorQueUno()
-        {
-            decimal valoracion = 1.1m;
-            var ex = Assert.Throws<ArgumentException>(() => new Atomo(1, valoracion));
-            Assert.StartsWith($"La valoración no puede ser mayor que 1: {valoracion}", ex.Message);
-        }
-
-        [Fact]
         public void Constructor_Posicion_SeAsigna()
         {
             int posicion = 1;
@@ -35,12 +27,14 @@
             Assert.Equal(posicion, atomo.Posicion);
         }
 
-        [Fact]
-        public void Constructor_Valoracion_SeAsigna()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(.5)]
+        [InlineData(10)]
+        public void Constructor_Valoracion_SeAsigna(double valoracion)
         {
-            decimal valoracion = 0.5m;
-            var atomo = new Atomo(1, valoracion);
-            Assert.Equal(valoracion, atomo.Valoracion);
+            var atomo = new Atomo(1, (decimal)valoracion);
+            Assert.Equal((decimal)valoracion, atomo.Valoracion);
         }
     }
 }


### PR DESCRIPTION
Este pull request modifica la clase `Atomo` eliminando la restricción que limitaba la valoración al rango [0,1]. Ahora se permiten valores mayores a 1. También se ajustaron los tests para reflejar este cambio.