### PR TITLE
mod(instancia-builder)!: se modificó InstanciaBuilder para que utilice matrices rectangulares en lugar de escalonadas

### DIFF
--- a/src/GeneradorInstancia/InstanciaBuilder.cs
+++ b/src/GeneradorInstancia/InstanciaBuilder.cs
@@ -56,9 +56,9 @@ namespace GeneradorInstancia
             return this;
         }
 
-        internal decimal[][] Build()
+        internal decimal[,] Build()
         {
-            decimal[][] instancia;
+            decimal[,] instancia;
 
             if (_valoracionesDisjuntas)
                 instancia = ConstruirInstanciaDisjunta();
@@ -68,7 +68,7 @@ namespace GeneradorInstancia
             return instancia;
         }
 
-        private decimal[][] ConstruirInstanciaDisjunta()
+        private decimal[,] ConstruirInstanciaDisjunta()
         {
             if (_cantidadAtomos < _cantidadJugadores)
             {
@@ -76,7 +76,7 @@ namespace GeneradorInstancia
                 throw new InvalidOperationException(mensaje);
             }
 
-            decimal[][] instancia = ConstruirInstanciaVacia();
+            decimal[,] instancia = ConstruirInstanciaVacia();
 
             List<int> atomosDisponibles = Enumerable.Range(0, _cantidadAtomos).ToList();
             List<int> jugadoresDisponibles = Enumerable.Range(0, _cantidadJugadores).ToList();
@@ -84,12 +84,11 @@ namespace GeneradorInstancia
             while (jugadoresDisponibles.Count > 0)
             {
                 int indiceAtomo = _generadorNumerosRandom.Siguiente(0, atomosDisponibles.Count);
-                int atomoElegido = atomosDisponibles[indiceAtomo];
-
                 int indiceJugador = _generadorNumerosRandom.Siguiente(0, jugadoresDisponibles.Count);
-                int jugadorElegido = jugadoresDisponibles[indiceJugador];
 
-                instancia[atomoElegido][jugadorElegido] = _generadorNumerosRandom.Siguiente(1, _valorMaximo + 1);
+                int atomoElegido = atomosDisponibles[indiceAtomo];
+                int jugadorElegido = jugadoresDisponibles[indiceJugador];
+                instancia[atomoElegido, jugadorElegido] = _generadorNumerosRandom.Siguiente(1, _valorMaximo + 1);
 
                 atomosDisponibles.RemoveAt(indiceAtomo);
                 jugadoresDisponibles.RemoveAt(indiceJugador);
@@ -101,7 +100,7 @@ namespace GeneradorInstancia
                 int jugadorElegido = _generadorNumerosRandom.Siguiente(0, _cantidadJugadores);
                 int atomoElegido = atomosDisponibles[indiceAtomo];
 
-                instancia[atomoElegido][jugadorElegido] = _generadorNumerosRandom.Siguiente(1, _valorMaximo + 1);
+                instancia[atomoElegido, jugadorElegido] = _generadorNumerosRandom.Siguiente(1, _valorMaximo + 1);
 
                 atomosDisponibles.RemoveAt(indiceAtomo);
             }
@@ -109,34 +108,28 @@ namespace GeneradorInstancia
             return instancia;
         }
 
-        private decimal[][] ConstruirInstanciaNoDisjunta()
+        private decimal[,] ConstruirInstanciaNoDisjunta()
         {
-            decimal[][] instancia = ConstruirInstanciaVacia();
+            decimal[,] instancia = ConstruirInstanciaVacia();
 
             for (int indiceAtomo = 0; indiceAtomo < _cantidadAtomos; indiceAtomo++)
             {
                 for (int indiceJugador = 0; indiceJugador < _cantidadJugadores; indiceJugador++)
                 {
                     int valorAleatorio = _generadorNumerosRandom.Siguiente(1, _valorMaximo + 1);
-                    instancia[indiceAtomo][indiceJugador] = valorAleatorio;
+                    instancia[indiceAtomo, indiceJugador] = valorAleatorio;
                 }
             }
 
             return instancia;
         }
 
-        private decimal[][] ConstruirInstanciaVacia()
+        private decimal[,] ConstruirInstanciaVacia()
         {
             if (_cantidadAtomos == 0 || _cantidadJugadores == 0)
                 throw new InvalidOperationException("Debe especificar el número de átomos y jugadores antes de construir la instancia");
 
-            var instancia = new decimal[_cantidadAtomos][];
-
-            for (int indiceAtomo = 0; indiceAtomo < _cantidadAtomos; indiceAtomo++)
-            {
-                instancia[indiceAtomo] = new decimal[_cantidadJugadores];
-            }
-
+            var instancia = new decimal[_cantidadAtomos, _cantidadJugadores];
             return instancia;
         }
     }

--- a/tests/GeneradorInstancias.Tests/InstanciaBuilderTests.cs
+++ b/tests/GeneradorInstancias.Tests/InstanciaBuilderTests.cs
@@ -74,10 +74,10 @@ namespace GeneradorInstancia.Tests
                 .ConCantidadDeAtomos(3)
                 .ConCantidadDeJugadores(2);
 
-            decimal[][] instancia = builder.Build();
+            decimal[,] instancia = builder.Build();
 
-            Assert.Equal(3, instancia.Length);
-            Assert.Equal(2, instancia[0].Length);
+            Assert.Equal(3, instancia.GetLength(0));
+            Assert.Equal(2, instancia.GetLength(1));
         }
 
         [Theory]
@@ -90,17 +90,17 @@ namespace GeneradorInstancia.Tests
                 .ConCantidadDeJugadores(3)
                 .ConValorMaximo(valorMaximo);
 
-            decimal[][] instancia = builder.Build();
+            decimal[,] instancia = builder.Build();
 
-            Assert.InRange(instancia[0][0], 0, valorMaximo);
-            Assert.InRange(instancia[0][1], 0, valorMaximo);
-            Assert.InRange(instancia[0][2], 0, valorMaximo);
-            Assert.InRange(instancia[1][0], 0, valorMaximo);
-            Assert.InRange(instancia[1][1], 0, valorMaximo);
-            Assert.InRange(instancia[1][2], 0, valorMaximo);
-            Assert.InRange(instancia[2][0], 0, valorMaximo);
-            Assert.InRange(instancia[2][1], 0, valorMaximo);
-            Assert.InRange(instancia[2][2], 0, valorMaximo);
+            Assert.InRange(instancia[0, 0], 0, valorMaximo);
+            Assert.InRange(instancia[0, 1], 0, valorMaximo);
+            Assert.InRange(instancia[0, 2], 0, valorMaximo);
+            Assert.InRange(instancia[1, 0], 0, valorMaximo);
+            Assert.InRange(instancia[1, 1], 0, valorMaximo);
+            Assert.InRange(instancia[1, 2], 0, valorMaximo);
+            Assert.InRange(instancia[2, 0], 0, valorMaximo);
+            Assert.InRange(instancia[2, 1], 0, valorMaximo);
+            Assert.InRange(instancia[2, 2], 0, valorMaximo);
         }
 
         [Fact]
@@ -112,50 +112,54 @@ namespace GeneradorInstancia.Tests
                 .ConValorMaximo(1)
                 .ConValoracionesDisjuntas(false);
 
-            decimal[][] instancia = builder.Build();
+            decimal[,] instancia = builder.Build();
 
-            Assert.NotEqual(0, instancia[0][0]);
-            Assert.NotEqual(0, instancia[0][1]);
-            Assert.NotEqual(0, instancia[0][2]);
-            Assert.NotEqual(0, instancia[1][0]);
-            Assert.NotEqual(0, instancia[1][1]);
-            Assert.NotEqual(0, instancia[1][2]);
-            Assert.NotEqual(0, instancia[2][0]);
-            Assert.NotEqual(0, instancia[2][1]);
-            Assert.NotEqual(0, instancia[2][2]);
+            Assert.NotEqual(0, instancia[0, 0]);
+            Assert.NotEqual(0, instancia[0, 1]);
+            Assert.NotEqual(0, instancia[0, 2]);
+            Assert.NotEqual(0, instancia[1, 0]);
+            Assert.NotEqual(0, instancia[1, 1]);
+            Assert.NotEqual(0, instancia[1, 2]);
+            Assert.NotEqual(0, instancia[2, 0]);
+            Assert.NotEqual(0, instancia[2, 1]);
+            Assert.NotEqual(0, instancia[2, 2]);
         }
 
         [Fact]
         public void Build_ValoracionesDisjuntas_CadaFilaTieneUnSoloValorPositivo()
         {
+            int jugadores = 3;
+
             var builder = new InstanciaBuilder()
                 .ConCantidadDeAtomos(4)
-                .ConCantidadDeJugadores(3)
+                .ConCantidadDeJugadores(jugadores)
                 .ConValorMaximo(5)
                 .ConValoracionesDisjuntas(true);
 
-            decimal[][] instancia = builder.Build();
+            decimal[,] instancia = builder.Build();
 
-            Assert.Equal(1, instancia[0].Count(v => v > 0));
-            Assert.Equal(1, instancia[1].Count(v => v > 0));
-            Assert.Equal(1, instancia[2].Count(v => v > 0));
-            Assert.Equal(1, instancia[3].Count(v => v > 0));
+            Assert.Equal(1, Enumerable.Range(0, jugadores).Count(j => instancia[0, j] > 0));
+            Assert.Equal(1, Enumerable.Range(0, jugadores).Count(j => instancia[1, j] > 0));
+            Assert.Equal(1, Enumerable.Range(0, jugadores).Count(j => instancia[2, j] > 0));
+            Assert.Equal(1, Enumerable.Range(0, jugadores).Count(j => instancia[3, j] > 0));
         }
 
         [Fact]
         public void Build_UnSoloJugadorValoracionesDisjuntas_AsignaTodaLaColumnaAlJugador()
         {
+            int jugadores = 1;
+
             var builder = new InstanciaBuilder()
                 .ConCantidadDeAtomos(3)
-                .ConCantidadDeJugadores(1)
+                .ConCantidadDeJugadores(jugadores)
                 .ConValorMaximo(5)
                 .ConValoracionesDisjuntas(true);
 
-            decimal[][] instancia = builder.Build();
+            decimal[,] instancia = builder.Build();
 
-            Assert.Equal(1, instancia[0].Count(v => v > 0));
-            Assert.Equal(1, instancia[1].Count(v => v > 0));
-            Assert.Equal(1, instancia[2].Count(v => v > 0));
+            Assert.Equal(1, Enumerable.Range(0, jugadores).Count(j => instancia[0, j] > 0));
+            Assert.Equal(1, Enumerable.Range(0, jugadores).Count(j => instancia[1, j] > 0));
+            Assert.Equal(1, Enumerable.Range(0, jugadores).Count(j => instancia[2, j] > 0));
         }
 
         [Fact]
@@ -167,17 +171,17 @@ namespace GeneradorInstancia.Tests
                 .ConValorMaximo(1)
                 .ConValoracionesDisjuntas(false);
 
-            decimal[][] instancia = builder.Build();
+            decimal[,] instancia = builder.Build();
 
-            Assert.NotEqual(0, instancia[0][0]);
-            Assert.NotEqual(0, instancia[0][1]);
-            Assert.NotEqual(0, instancia[0][2]);
-            Assert.NotEqual(0, instancia[1][0]);
-            Assert.NotEqual(0, instancia[1][1]);
-            Assert.NotEqual(0, instancia[1][2]);
-            Assert.NotEqual(0, instancia[2][0]);
-            Assert.NotEqual(0, instancia[2][1]);
-            Assert.NotEqual(0, instancia[2][2]);
+            Assert.NotEqual(0, instancia[0, 0]);
+            Assert.NotEqual(0, instancia[0, 1]);
+            Assert.NotEqual(0, instancia[0, 2]);
+            Assert.NotEqual(0, instancia[1, 0]);
+            Assert.NotEqual(0, instancia[1, 1]);
+            Assert.NotEqual(0, instancia[1, 2]);
+            Assert.NotEqual(0, instancia[2, 0]);
+            Assert.NotEqual(0, instancia[2, 1]);
+            Assert.NotEqual(0, instancia[2, 2]);
         }
     }
 }


### PR DESCRIPTION
Este pull request incluye cambios en la clase `InstanciaBuilder` y sus tests para actualizar la estructura de datos usada para las instancias, pasando de un arreglo escalonado (`decimal[][]`) a un arreglo rectangular (`decimal[,]`). Los cambios más importantes incluyen modificaciones en el método `Build`, en los métodos de construcción de instancias y en los tests.