### PR TITLE
refactor(tests): uso de constructor como función de setup

### DIFF
--- a/tests/App.Tests/GenerarCommandTests.cs
+++ b/tests/App.Tests/GenerarCommandTests.cs
@@ -16,6 +16,17 @@ namespace App.Tests
         }
 
         [Fact]
+        public void Create_NombreYOpciones_ConfiguradasCorrectamente()
+        {
+            Assert.Equal("generar", _command.Name);
+            Assert.Contains(_command.Options, o => o.Name == "atomos");
+            Assert.Contains(_command.Options, o => o.Name == "agentes");
+            Assert.Contains(_command.Options, o => o.Name == "valor-maximo");
+            Assert.Contains(_command.Options, o => o.Name == "output");
+            Assert.Contains(_command.Options, o => o.Name == "disjuntas");
+        }
+
+        [Fact]
         public void Create_ValorMaximoNoEspecificado_UsaValorPorDefecto()
         {
             var valorMaximoOption = (Option<int>)_command.Options.First(o => o.Name == "valor-maximo");
@@ -40,17 +51,6 @@ namespace App.Tests
             bool disjuntas = _command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(disjuntasOption);
 
             Assert.False(disjuntas);
-        }
-
-        [Fact]
-        public void Create_Command_ConfiguraOpcionesCorrectamente()
-        {
-            Assert.Equal("generar", _command.Name);
-            Assert.Contains(_command.Options, o => o.Name == "atomos");
-            Assert.Contains(_command.Options, o => o.Name == "agentes");
-            Assert.Contains(_command.Options, o => o.Name == "valor-maximo");
-            Assert.Contains(_command.Options, o => o.Name == "output");
-            Assert.Contains(_command.Options, o => o.Name == "disjuntas");
         }
 
         [Fact]

--- a/tests/App.Tests/GenerarCommandTests.cs
+++ b/tests/App.Tests/GenerarCommandTests.cs
@@ -8,12 +8,18 @@ namespace App.Tests
 {
     public class GenerarCommandTests
     {
+        private readonly Command _command;
+
+        public GenerarCommandTests()
+        {
+            _command = GenerarCommand.Create();
+        }
+
         [Fact]
         public void Create_ValorMaximoNoEspecificado_UsaValorPorDefecto()
         {
-            var command = GenerarCommand.Create();
-            var valorMaximoOption = (Option<int>)command.Options.First(o => o.Name == "valor-maximo");
-            int valorMaximo = command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(valorMaximoOption);
+            var valorMaximoOption = (Option<int>)_command.Options.First(o => o.Name == "valor-maximo");
+            int valorMaximo = _command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(valorMaximoOption);
 
             Assert.Equal(GenerarCommand.ValorMaximoPorDefecto, valorMaximo);
         }
@@ -21,9 +27,8 @@ namespace App.Tests
         [Fact]
         public void Create_OutputNoEspecificada_UsaValorPorDefecto()
         {
-            var command = GenerarCommand.Create();
-            var outputOption = (Option<string>)command.Options.First(o => o.Name == "output");
-            string output = command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(outputOption);
+            var outputOption = (Option<string>)_command.Options.First(o => o.Name == "output");
+            string output = _command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(outputOption);
 
             Assert.Equal(GenerarCommand.RutaSalidaPorDefecto, output);
         }
@@ -31,9 +36,8 @@ namespace App.Tests
         [Fact]
         public void Create_DisjuntasNoEspecificada_UsaFalse()
         {
-            var command = GenerarCommand.Create();
-            var disjuntasOption = (Option<bool>)command.Options.First(o => o.Name == "disjuntas");
-            bool disjuntas = command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(disjuntasOption);
+            var disjuntasOption = (Option<bool>)_command.Options.First(o => o.Name == "disjuntas");
+            bool disjuntas = _command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(disjuntasOption);
 
             Assert.False(disjuntas);
         }
@@ -41,14 +45,12 @@ namespace App.Tests
         [Fact]
         public void Create_Command_ConfiguraOpcionesCorrectamente()
         {
-            var command = GenerarCommand.Create();
-
-            Assert.Equal("generar", command.Name);
-            Assert.Contains(command.Options, o => o.Name == "atomos");
-            Assert.Contains(command.Options, o => o.Name == "agentes");
-            Assert.Contains(command.Options, o => o.Name == "valor-maximo");
-            Assert.Contains(command.Options, o => o.Name == "output");
-            Assert.Contains(command.Options, o => o.Name == "disjuntas");
+            Assert.Equal("generar", _command.Name);
+            Assert.Contains(_command.Options, o => o.Name == "atomos");
+            Assert.Contains(_command.Options, o => o.Name == "agentes");
+            Assert.Contains(_command.Options, o => o.Name == "valor-maximo");
+            Assert.Contains(_command.Options, o => o.Name == "output");
+            Assert.Contains(_command.Options, o => o.Name == "disjuntas");
         }
 
         [Fact]

--- a/tests/GeneradorInstancias.Tests/EscritorInstanciaTests.cs
+++ b/tests/GeneradorInstancias.Tests/EscritorInstanciaTests.cs
@@ -5,6 +5,9 @@ namespace GeneradorInstancia.Tests
 {
     public class EscritorInstanciaTests
     {
+        private const string DirectorioSalida = "nombreCarpeta";
+        private const string NombreArchivoSalida = "instancia.dat";
+
         private readonly decimal[,] _instancia = new decimal[1, 1] { { 1 } };
 
         private readonly FileSystemHelper _fileSystemHelper;
@@ -25,7 +28,7 @@ namespace GeneradorInstancia.Tests
         [Fact]
         public void EscribirInstancia_InstanciaNull_LanzaArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => _escritorInstancia.EscribirInstancia(null, "ruta.dat"));
+            Assert.Throws<ArgumentNullException>(() => _escritorInstancia.EscribirInstancia(null, NombreArchivoSalida));
         }
 
         [Theory]
@@ -41,7 +44,7 @@ namespace GeneradorInstancia.Tests
         [Fact]
         public void EscribirInstancia_RutaSinDirectorio_NoPreguntaSiExisteNiIntentaCrearDirectorio()
         {
-            _escritorInstancia.EscribirInstancia(_instancia, "instancia.dat");
+            _escritorInstancia.EscribirInstancia(_instancia, NombreArchivoSalida);
 
             _fileSystemHelper.DidNotReceive().DirectoryExists(Arg.Any<string>());
             _fileSystemHelper.DidNotReceive().CreateDirectory(Arg.Any<string>());
@@ -50,9 +53,9 @@ namespace GeneradorInstancia.Tests
         [Fact]
         public void EscribirInstancia_DirectorioExistente_NoIntentaCrearlo()
         {
-            _fileSystemHelper.DirectoryExists("carpeta").Returns(true);
+            _fileSystemHelper.DirectoryExists(DirectorioSalida).Returns(true);
 
-            _escritorInstancia.EscribirInstancia(_instancia, "carpeta/instancia.dat");
+            _escritorInstancia.EscribirInstancia(_instancia, DirectorioSalida + "/" + NombreArchivoSalida);
 
             _fileSystemHelper.DidNotReceive().CreateDirectory(Arg.Any<string>());
         }
@@ -60,21 +63,19 @@ namespace GeneradorInstancia.Tests
         [Fact]
         public void EscribirInstancia_DirectorioNoExistente_LoCrea()
         {
-            _fileSystemHelper.DirectoryExists("carpeta").Returns(false);
+            _fileSystemHelper.DirectoryExists(DirectorioSalida).Returns(false);
 
-            _escritorInstancia.EscribirInstancia(_instancia, "carpeta/instancia.dat");
+            _escritorInstancia.EscribirInstancia(_instancia, DirectorioSalida + "/" + NombreArchivoSalida);
 
-            _fileSystemHelper.Received(1).CreateDirectory("carpeta");
+            _fileSystemHelper.Received(1).CreateDirectory(DirectorioSalida);
         }
 
         [Fact]
         public void EscribirInstancia_InstanciaValida_EscribeContenidoCorrecto()
         {
-            const string ruta = "instancia.dat";
+            _escritorInstancia.EscribirInstancia(new decimal[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } }, NombreArchivoSalida);
 
-            _escritorInstancia.EscribirInstancia(new decimal[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } }, ruta);
-
-            _fileSystemHelper.Received(1).WriteAllLines(ruta, Arg.Is<List<string>>(x =>
+            _fileSystemHelper.Received(1).WriteAllLines(NombreArchivoSalida, Arg.Is<List<string>>(x =>
                 x.Count == 3 &&
                 x[0] == "2 3" &&
                 x[1] == "1\t2\t3" &&
@@ -85,11 +86,9 @@ namespace GeneradorInstancia.Tests
         [Fact]
         public void EscribirInstancia_InstanciaVacia_EscribeSoloEncabezado()
         {
-            const string ruta = "vacio.dat";
+            _escritorInstancia.EscribirInstancia(new decimal[0, 0], NombreArchivoSalida);
 
-            _escritorInstancia.EscribirInstancia(new decimal[0, 0], ruta);
-
-            _fileSystemHelper.Received(1).WriteAllLines(ruta, Arg.Is<List<string>>(x =>
+            _fileSystemHelper.Received(1).WriteAllLines(NombreArchivoSalida, Arg.Is<List<string>>(x =>
                 x.Count == 1 &&
                 x[0] == "0 0"
             ));
@@ -102,7 +101,7 @@ namespace GeneradorInstancia.Tests
                 .When(x => x.WriteAllLines(Arg.Any<string>(), Arg.Any<List<string>>()))
                 .Throw(new IOException("Error de disco"));
 
-            var ex = Assert.Throws<IOException>(() => _escritorInstancia.EscribirInstancia(_instancia, "instancia.dat"));
+            var ex = Assert.Throws<IOException>(() => _escritorInstancia.EscribirInstancia(_instancia, NombreArchivoSalida));
             Assert.Equal("Error al escribir la instancia: Error de disco", ex.Message);
         }
     }

--- a/tests/Solver.Tests/AgenteTests.cs
+++ b/tests/Solver.Tests/AgenteTests.cs
@@ -2,20 +2,26 @@
 {
     public class AgenteTests
     {
+        private const int IdAgente = 1;
+
+        private readonly Agente _agente;
+
+        public AgenteTests()
+        {
+            _agente = new Agente(IdAgente);
+        }
+
         [Fact]
         public void Constructor_Id_SeAsigna()
         {
-            int id = 1;
-            var agente = new Agente(id);
-            Assert.Equal(id, agente.Id);
+            Assert.Equal(IdAgente, _agente.Id);
         }
 
         [Fact]
         public void Constructor_Valoraciones_SeInicializaVacia()
         {
-            var agente = new Agente(1);
-            Assert.NotNull(agente.Valoraciones);
-            Assert.Empty(agente.Valoraciones);
+            Assert.NotNull(_agente.Valoraciones);
+            Assert.Empty(_agente.Valoraciones);
         }
 
         [Fact]
@@ -24,24 +30,22 @@
             var atomo1 = new Atomo(1, 1);
             var atomo2 = new Atomo(2, 1);
 
-            var agente = new Agente(1);
-            agente.AgregarValoracion(atomo1);
-            agente.AgregarValoracion(atomo2);
+            _agente.AgregarValoracion(atomo1);
+            _agente.AgregarValoracion(atomo2);
 
-            Assert.True(agente.Valoraciones.Count == 2);
-            Assert.Same(atomo1, agente.Valoraciones[0]);
-            Assert.Same(atomo2, agente.Valoraciones[1]);
+            Assert.True(_agente.Valoraciones.Count == 2);
+            Assert.Same(atomo1, _agente.Valoraciones[0]);
+            Assert.Same(atomo2, _agente.Valoraciones[1]);
         }
 
         [Fact]
         public void AgregarValoracion_ValoracionSobreMismoAtomo_LanzaInvalidOperationException()
         {
-            int posicionAtomo = 1;
+            const int posicionAtomo = 1;
 
-            var agente = new Agente(1);
-            agente.AgregarValoracion(new Atomo(posicionAtomo, 1));
+            _agente.AgregarValoracion(new Atomo(posicionAtomo, 1));
 
-            var ex = Assert.Throws<InvalidOperationException>(() => agente.AgregarValoracion(new Atomo(posicionAtomo, 0)));
+            var ex = Assert.Throws<InvalidOperationException>(() => _agente.AgregarValoracion(new Atomo(posicionAtomo, 0)));
             Assert.Equal($"Ya existe una valoración para el átomo #{posicionAtomo}", ex.Message);
         }
     }


### PR DESCRIPTION
En este PR se modificaron algunas clases de tests para para extraer código repetido como variable de instancia o constante de la clase.