### PR TITLE
feat(generador-instancia)!: remoción de valores por defecto del builder

### DIFF
--- a/src/App/GenerarCommand.cs
+++ b/src/App/GenerarCommand.cs
@@ -25,9 +25,9 @@ namespace App
             command.AddOption(outputOption);
             command.AddOption(disjuntasOption);
 
-            command.SetHandler((atomos, agentes, max, output, disjuntas) =>
+            command.SetHandler((atomos, agentes, valorMaximo, output, disjuntas) =>
             {
-                var parametros = new ParametrosGeneracion(atomos, agentes, max, output, disjuntas);
+                var parametros = new ParametrosGeneracion(atomos, agentes, valorMaximo, output, disjuntas);
                 var builder = new InstanciaBuilder();
                 var escritor = new EscritorInstancia(new FileSystemHelper());
                 Handler(parametros, builder, escritor);

--- a/src/GeneradorInstancia/InstanciaBuilder.cs
+++ b/src/GeneradorInstancia/InstanciaBuilder.cs
@@ -58,6 +58,12 @@ namespace GeneradorInstancia
 
         public virtual decimal[,] Build()
         {
+            if (_cantidadAtomos == 0)
+                throw new InvalidOperationException("Debe especificar el número de átomos antes de construir la instancia");
+
+            if (_cantidadAgentes == 0)
+                throw new InvalidOperationException("Debe especificar el número de agentes antes de construir la instancia");
+
             decimal[,] instancia;
 
             if (_valoracionesDisjuntas)
@@ -76,7 +82,7 @@ namespace GeneradorInstancia
                 throw new InvalidOperationException(mensaje);
             }
 
-            decimal[,] instancia = ConstruirInstanciaVacia();
+            var instancia = new decimal[_cantidadAtomos, _cantidadAgentes];
 
             List<int> atomosDisponibles = Enumerable.Range(0, _cantidadAtomos).ToList();
             List<int> agentesDisponibles = Enumerable.Range(0, _cantidadAgentes).ToList();
@@ -110,7 +116,7 @@ namespace GeneradorInstancia
 
         private decimal[,] ConstruirInstanciaNoDisjunta()
         {
-            decimal[,] instancia = ConstruirInstanciaVacia();
+            var instancia = new decimal[_cantidadAtomos, _cantidadAgentes];
 
             for (int indiceAtomo = 0; indiceAtomo < _cantidadAtomos; indiceAtomo++)
             {
@@ -121,15 +127,6 @@ namespace GeneradorInstancia
                 }
             }
 
-            return instancia;
-        }
-
-        private decimal[,] ConstruirInstanciaVacia()
-        {
-            if (_cantidadAtomos == 0 || _cantidadAgentes == 0)
-                throw new InvalidOperationException("Debe especificar el número de átomos y agentes antes de construir la instancia");
-
-            var instancia = new decimal[_cantidadAtomos, _cantidadAgentes];
             return instancia;
         }
     }

--- a/src/GeneradorInstancia/InstanciaBuilder.cs
+++ b/src/GeneradorInstancia/InstanciaBuilder.cs
@@ -7,7 +7,7 @@ namespace GeneradorInstancia
         private int _cantidadAtomos;
         private int _cantidadAgentes;
         private int _valorMaximo;
-        private bool _valoracionesDisjuntas;
+        private bool? _valoracionesDisjuntas;
 
         private readonly GeneradorNumerosRandom _generadorNumerosRandom;
 
@@ -66,9 +66,12 @@ namespace GeneradorInstancia
             if (_valorMaximo == 0)
                 throw new InvalidOperationException("Debe especificar el valor máximo antes de construir la instancia");
 
+            if (!_valoracionesDisjuntas.HasValue)
+                throw new InvalidOperationException("Debe especificar el tipo (disjunta o no disjunta) antes de construir la instancia");
+
             decimal[,] instancia;
 
-            if (_valoracionesDisjuntas)
+            if (_valoracionesDisjuntas.Value)
                 instancia = ConstruirInstanciaDisjunta();
             else
                 instancia = ConstruirInstanciaNoDisjunta();

--- a/src/GeneradorInstancia/InstanciaBuilder.cs
+++ b/src/GeneradorInstancia/InstanciaBuilder.cs
@@ -4,11 +4,10 @@ namespace GeneradorInstancia
 {
     public class InstanciaBuilder
     {
-        private int _valorMaximo = 1000;
-        private bool _valoracionesDisjuntas = false;
-
         private int _cantidadAtomos;
         private int _cantidadAgentes;
+        private int _valorMaximo;
+        private bool _valoracionesDisjuntas;
 
         private readonly GeneradorNumerosRandom _generadorNumerosRandom;
 
@@ -63,6 +62,9 @@ namespace GeneradorInstancia
 
             if (_cantidadAgentes == 0)
                 throw new InvalidOperationException("Debe especificar el número de agentes antes de construir la instancia");
+
+            if (_valorMaximo == 0)
+                throw new InvalidOperationException("Debe especificar el valor máximo antes de construir la instancia");
 
             decimal[,] instancia;
 

--- a/tests/GeneradorInstancias.Tests/InstanciaBuilderTests.cs
+++ b/tests/GeneradorInstancias.Tests/InstanciaBuilderTests.cs
@@ -57,11 +57,23 @@ namespace GeneradorInstancia.Tests
         }
 
         [Fact]
+        public void Build_SinValorMaximoSeteado_LanzaInvalidOperationException()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
+                .ConCantidadDeAtomos(2)
+                .ConCantidadDeAgentes(2)
+                .Build);
+
+            Assert.Equal("Debe especificar el valor máximo antes de construir la instancia", ex.Message);
+        }
+
+        [Fact]
         public void Build_ValoracionesDisjuntasConMasAgentesQueAtomos_LanzaInvalidOperationException()
         {
             var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
                 .ConCantidadDeAtomos(2)
                 .ConCantidadDeAgentes(3)
+                .ConValorMaximo(5)
                 .ConValoracionesDisjuntas(true)
                 .Build);
 
@@ -74,6 +86,7 @@ namespace GeneradorInstancia.Tests
             decimal[,] instancia = _instanciaBuilder
                 .ConCantidadDeAtomos(3)
                 .ConCantidadDeAgentes(2)
+                .ConValorMaximo(5)
                 .Build();
 
             Assert.Equal(3, instancia.GetLength(0));

--- a/tests/GeneradorInstancias.Tests/InstanciaBuilderTests.cs
+++ b/tests/GeneradorInstancias.Tests/InstanciaBuilderTests.cs
@@ -37,24 +37,23 @@ namespace GeneradorInstancia.Tests
         }
 
         [Fact]
-        public void Build_SinConfiguracionPrevia_LanzaInvalidOperationException()
+        public void Build_SinAtomosSeteados_LanzaInvalidOperationException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder.Build);
-            Assert.Equal("Debe especificar el número de átomos y agentes antes de construir la instancia", ex.Message);
+            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
+                .ConCantidadDeAgentes(2)
+                .Build);
+
+            Assert.Equal("Debe especificar el número de átomos antes de construir la instancia", ex.Message);
         }
 
         [Fact]
-        public void Build_SoloAtomosConfigurados_LanzaInvalidOperationException()
+        public void Build_SinAgentesSeteados_LanzaInvalidOperationException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder.ConCantidadDeAtomos(2).Build);
-            Assert.Equal("Debe especificar el número de átomos y agentes antes de construir la instancia", ex.Message);
-        }
+            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
+                .ConCantidadDeAtomos(2)
+                .Build);
 
-        [Fact]
-        public void Build_SoloAgentesConfigurados_LanzaInvalidOperationException()
-        {
-            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder.ConCantidadDeAgentes(2).Build);
-            Assert.Equal("Debe especificar el número de átomos y agentes antes de construir la instancia", ex.Message);
+            Assert.Equal("Debe especificar el número de agentes antes de construir la instancia", ex.Message);
         }
 
         [Fact]

--- a/tests/GeneradorInstancias.Tests/InstanciaBuilderTests.cs
+++ b/tests/GeneradorInstancias.Tests/InstanciaBuilderTests.cs
@@ -39,10 +39,7 @@ namespace GeneradorInstancia.Tests
         [Fact]
         public void Build_SinAtomosSeteados_LanzaInvalidOperationException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
-                .ConCantidadDeAgentes(2)
-                .Build);
-
+            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder.Build);
             Assert.Equal("Debe especificar el número de átomos antes de construir la instancia", ex.Message);
         }
 
@@ -68,6 +65,18 @@ namespace GeneradorInstancia.Tests
         }
 
         [Fact]
+        public void Build_SinTipoDeInstanciaSeteado_LanzaInvalidOperationException()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
+                .ConCantidadDeAtomos(2)
+                .ConCantidadDeAgentes(2)
+                .ConValorMaximo(5)
+                .Build);
+
+            Assert.Equal("Debe especificar el tipo (disjunta o no disjunta) antes de construir la instancia", ex.Message);
+        }
+
+        [Fact]
         public void Build_ValoracionesDisjuntasConMasAgentesQueAtomos_LanzaInvalidOperationException()
         {
             var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
@@ -81,12 +90,13 @@ namespace GeneradorInstancia.Tests
         }
 
         [Fact]
-        public void Build_AtomosYAgentesValidos_DevuelveMatrizCorrecta()
+        public void Build_ConfiguracionCorrecta_DevuelveMatrizCorrecta()
         {
             decimal[,] instancia = _instanciaBuilder
                 .ConCantidadDeAtomos(3)
                 .ConCantidadDeAgentes(2)
                 .ConValorMaximo(5)
+                .ConValoracionesDisjuntas(true)
                 .Build();
 
             Assert.Equal(3, instancia.GetLength(0));
@@ -102,6 +112,7 @@ namespace GeneradorInstancia.Tests
                 .ConCantidadDeAtomos(3)
                 .ConCantidadDeAgentes(3)
                 .ConValorMaximo(valorMaximo)
+                .ConValoracionesDisjuntas(false)
                 .Build();
 
             Assert.InRange(instancia[0, 0], 0, valorMaximo);


### PR DESCRIPTION
En este PR se removieron los valores por defectos de la clase `InstanciaBuilder` para la cota superior en las valoraciones (`_valorMaximo`) y para el tipo de instancia (`_valoracionesDisjuntas`). Se arroja una excepción si se invoca a `Build` sin haber configurado esos valores.

BREAKING CHANGE: Se volvieron obligatorios los llamados a `ConValorMaximo(int)` y `ConValoracionesDisjuntas(bool)` de `InstanciaBuilder` antes de hacer `Build`. Arroja `InvalidOperationException` si no se invocaron.