### PR TITLE
tests(proyecto): se agregaron asserts de nombre de parámetro

### DIFF
--- a/src/App/ParametrosGeneracion.cs
+++ b/src/App/ParametrosGeneracion.cs
@@ -46,18 +46,18 @@ namespace App
                 throw new ArgumentException("El valor máximo debe ser positivo", nameof(valorMaximo));
         }
 
-        private void ValidarRuta(string ruta)
+        private void ValidarRuta(string rutaSalida)
         {
-            if (string.IsNullOrWhiteSpace(ruta))
-                throw new ArgumentException("La ruta no puede estar vacía", nameof(ruta));
+            if (string.IsNullOrWhiteSpace(rutaSalida))
+                throw new ArgumentException("La ruta no puede estar vacía", nameof(rutaSalida));
 
             try
             {
-                _fileSystemHelper.GetFullPath(ruta);
+                _fileSystemHelper.GetFullPath(rutaSalida);
             }
             catch (Exception ex)
             {
-                throw new ArgumentException("Ruta inválida: " + ex.Message, nameof(ruta));
+                throw new ArgumentException("Ruta inválida: " + ex.Message, nameof(rutaSalida));
             }
         }
     }

--- a/tests/App.Tests/ParametrosGeneracionTests.cs
+++ b/tests/App.Tests/ParametrosGeneracionTests.cs
@@ -17,6 +17,7 @@ namespace App.Tests
         {
             var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(0, 1, 100, "instancia.dat", false));
             Assert.StartsWith("Se requieren al menos 1 átomo", ex.Message);
+            Assert.Equal("atomos", ex.ParamName);
         }
 
         [Fact]
@@ -24,6 +25,7 @@ namespace App.Tests
         {
             var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 0, 100, "instancia.dat", false));
             Assert.StartsWith("Se requieren al menos 1 agente", ex.Message);
+            Assert.Equal("agentes", ex.ParamName);
         }
 
         [Theory]
@@ -33,6 +35,7 @@ namespace App.Tests
         {
             var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, valorMaximo, "instancia.dat", false));
             Assert.StartsWith("El valor máximo debe ser positivo", ex.Message);
+            Assert.Equal("valorMaximo", ex.ParamName);
         }
 
         [Theory]
@@ -43,6 +46,7 @@ namespace App.Tests
         {
             var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, 100, rutaSalida, false));
             Assert.StartsWith("La ruta no puede estar vacía", ex.Message);
+            Assert.Equal("rutaSalida", ex.ParamName);
         }
 
         [Fact]
@@ -54,6 +58,7 @@ namespace App.Tests
 
             var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, 100, "¡ruta-inválida!", false));
             Assert.StartsWith($"Ruta inválida: La ruta es inválida", ex.Message);
+            Assert.Equal("rutaSalida", ex.ParamName);
         }
 
         [Fact]

--- a/tests/Common.Tests/GeneradorNumerosRandomTests.cs
+++ b/tests/Common.Tests/GeneradorNumerosRandomTests.cs
@@ -7,6 +7,7 @@
         {
             var ex = Assert.Throws<ArgumentException>(() => new GeneradorNumerosRandom(-1));
             Assert.StartsWith("La semilla no puede ser negativa: -1", ex.Message);
+            Assert.Equal("seed", ex.ParamName);
         }
 
         [Fact]

--- a/tests/Generator.Tests/EscritorInstanciaTests.cs
+++ b/tests/Generator.Tests/EscritorInstanciaTests.cs
@@ -24,6 +24,7 @@ namespace Generator.Tests
         {
             var ex = Assert.Throws<ArgumentNullException>(() => new EscritorInstancia(null));
             Assert.Contains("fileSystem", ex.Message);
+            Assert.Equal("fileSystem", ex.ParamName);
         }
 
         [Fact]
@@ -31,6 +32,7 @@ namespace Generator.Tests
         {
             var ex = Assert.Throws<ArgumentNullException>(() => _escritorInstancia.EscribirInstancia(null, NombreArchivoSalida));
             Assert.Contains("instancia", ex.Message);
+            Assert.Equal("instancia", ex.ParamName);
         }
 
         [Theory]
@@ -41,6 +43,7 @@ namespace Generator.Tests
         {
             var ex = Assert.Throws<ArgumentException>(() => _escritorInstancia.EscribirInstancia(_instancia, rutaInvalida));
             Assert.StartsWith("La ruta no puede estar vacía", ex.Message);
+            Assert.Equal("rutaArchivo", ex.ParamName);
         }
 
         [Fact]

--- a/tests/Generator.Tests/InstanciaBuilderTests.cs
+++ b/tests/Generator.Tests/InstanciaBuilderTests.cs
@@ -17,7 +17,7 @@ namespace Generator.Tests
         public void Constructor_GeneradorNumerosRandomNull_LanzaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => new InstanciaBuilder(null));
-            Assert.Contains("generadorNumerosRandom", ex.Message);
+            Assert.Equal("generadorNumerosRandom", ex.ParamName);
         }
 
         [Theory]
@@ -27,6 +27,7 @@ namespace Generator.Tests
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _instanciaBuilder.ConCantidadDeAtomos(cantidadAtomos));
             Assert.StartsWith($"La cantidad de átomos debe ser mayor a cero: {cantidadAtomos}", ex.Message);
+            Assert.Equal("cantidadAtomos", ex.ParamName);
         }
 
         [Theory]
@@ -36,6 +37,7 @@ namespace Generator.Tests
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _instanciaBuilder.ConCantidadDeAgentes(cantidadAgentes));
             Assert.StartsWith($"La cantidad de agentes debe ser mayor a cero: {cantidadAgentes}", ex.Message);
+            Assert.Equal("cantidadAgentes", ex.ParamName);
         }
 
         [Theory]
@@ -45,6 +47,7 @@ namespace Generator.Tests
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _instanciaBuilder.ConValorMaximo(valorMaximo));
             Assert.StartsWith($"El valor máximo debe ser positivo: {valorMaximo}", ex.Message);
+            Assert.Equal("valorMaximo", ex.ParamName);
         }
 
         [Fact]

--- a/tests/Solver.Tests/AtomoTests.cs
+++ b/tests/Solver.Tests/AtomoTests.cs
@@ -9,6 +9,7 @@
         {
             var ex = Assert.Throws<ArgumentException>(() => new Atomo(posicion, 1));
             Assert.StartsWith($"La posición debe ser positiva: {posicion}", ex.Message);
+            Assert.Equal("posicion", ex.ParamName);
         }
 
         [Fact]
@@ -17,6 +18,7 @@
             decimal valoracion = -0.1m;
             var ex = Assert.Throws<ArgumentException>(() => new Atomo(1, valoracion));
             Assert.StartsWith($"La valoración no puede ser negativa: {valoracion}", ex.Message);
+            Assert.Equal("valoracion", ex.ParamName);
         }
 
         [Fact]

--- a/tests/Solver.Tests/Individuos/IndividuoTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoTests.cs
@@ -9,23 +9,26 @@ namespace Solver.Tests.Individuos
         public void Constructor_CromosomaNull_LanzaArgumentNullException()
         {
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,] { { 1 } });
+
             var ex = Assert.Throws<ArgumentNullException>(() => new IndividuoStub(null, instanciaProblema));
-            Assert.Contains("cromosoma", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]
         public void Constructor_InstanciaProblemaNull_LanzaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => new IndividuoStub([], null));
-            Assert.Contains("problema", ex.Message);
+            Assert.Equal("problema", ex.ParamName);
         }
 
         [Fact]
         public void Constructor_CromosomaVacio_LanzaArgumentException()
         {
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,] { { 1 } });
+
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([], instanciaProblema));
             Assert.StartsWith("El cromosoma no puede estar vacío", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]
@@ -34,8 +37,10 @@ namespace Solver.Tests.Individuos
             // Para k agentes se esperan k-1 cortes y k asignaciones
             decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
+
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([1, 2], instanciaProblema));
             Assert.StartsWith("Cantidad de genes inválida. Esperada: 3, recibida: 2", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]
@@ -43,8 +48,10 @@ namespace Solver.Tests.Individuos
         {
             decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
+
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([-1, 2, 1], instanciaProblema));
             Assert.StartsWith($"Posición del primer corte no puede ser negativa: -1", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]
@@ -52,8 +59,10 @@ namespace Solver.Tests.Individuos
         {
             decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
+
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([3, 2, 1], instanciaProblema));
             Assert.StartsWith("Posición del último corte no puede superar a 2: 3", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]
@@ -62,8 +71,10 @@ namespace Solver.Tests.Individuos
             // El rango permitido para las asignaciones de k agentes es [1, k]
             decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
+
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 1, 0], instanciaProblema));
             Assert.StartsWith($"Hay asignaciones fuera del rango [1, 2]: (0)", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]
@@ -71,8 +82,10 @@ namespace Solver.Tests.Individuos
         {
             decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
+
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, -1, 5], instanciaProblema));
             Assert.StartsWith("Hay asignaciones fuera del rango [1, 2]: (-1, 5)", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]
@@ -86,8 +99,10 @@ namespace Solver.Tests.Individuos
                 { 0m, 0m, 0m, 1m }
             };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
+
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([1, 2, 3, 5, 2, 0, -1], instanciaProblema));
             Assert.StartsWith("Hay asignaciones fuera del rango [1, 4]: (-1, 0, 5)", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]
@@ -95,8 +110,10 @@ namespace Solver.Tests.Individuos
         {
             decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
+
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 1, 1], instanciaProblema));
             Assert.StartsWith("Hay porciones asignadas a más de un agente: (1)", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]
@@ -110,8 +127,10 @@ namespace Solver.Tests.Individuos
                 { 0m, 0m, 0m, 1m }
             };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
+
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 0, 4, 2, 2, 3, 3], instanciaProblema));
             Assert.StartsWith("Hay porciones asignadas a más de un agente: (2, 3)", ex.Message);
+            Assert.Equal("cromosoma", ex.ParamName);
         }
 
         [Fact]

--- a/tests/Solver.Tests/InstanciaProblemaTests.cs
+++ b/tests/Solver.Tests/InstanciaProblemaTests.cs
@@ -6,7 +6,7 @@
         public void CrearDesdeMatrizDeValoraciones_MatrizNull_LanzaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => InstanciaProblema.CrearDesdeMatrizDeValoraciones(null));
-            Assert.Contains("matrizValoraciones", ex.Message);
+            Assert.Equal("matrizValoraciones", ex.ParamName);
         }
 
         [Fact]
@@ -15,6 +15,7 @@
             var matriz = new decimal[0, 0];
             var ex = Assert.Throws<ArgumentException>(() => InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz));
             Assert.StartsWith("La matriz de valoraciones no puede estar vacía", ex.Message);
+            Assert.Equal("matrizValoraciones", ex.ParamName);
         }
 
         [Fact]
@@ -26,6 +27,7 @@
             };
             var ex = Assert.Throws<ArgumentException>(() => InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz));
             Assert.StartsWith("El agente 1 no tiene valoraciones positivas sobre ningún átomo", ex.Message);
+            Assert.Equal("matrizValoraciones", ex.ParamName);
         }
 
         [Fact]

--- a/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
+++ b/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
@@ -23,14 +23,14 @@ namespace Solver.Tests
         public void Constructor_FileSystemHelperNull_ArrojaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => new LectorArchivoMatrizValoraciones(null));
-            Assert.Contains("fileSystemHelper", ex.Message);
+            Assert.Equal("fileSystemHelper", ex.ParamName);
         }
 
         [Fact]
         public void Leer_RutaNull_ArrojaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => _lector.Leer(null));
-            Assert.Contains("rutaArchivo", ex.Message);
+            Assert.Equal("rutaArchivo", ex.ParamName);
         }
 
         [Theory]
@@ -43,6 +43,7 @@ namespace Solver.Tests
 
             var ex = Assert.Throws<ArgumentException>(() => _lector.Leer(rutaArchivo));
             Assert.StartsWith($"No existe el archivo '{rutaArchivo}'", ex.Message);
+            Assert.Equal("rutaArchivo", ex.ParamName);
         }
 
         [Fact]


### PR DESCRIPTION
Este PR actualiza varios tests para verificar los nombres de los parámetros de las excepciones lanzadas de tipo `ArgumentException`, `ArgumentNullException` y `ArgumentOutOfRangeException`.