### PR TITLE
refactor(tests): actualización de tests para cumplir convenciones

### DIFF
--- a/src/Solver/Agente.cs
+++ b/src/Solver/Agente.cs
@@ -13,7 +13,7 @@
         internal void AgregarValoracion(Atomo atomo)
         {
             if (Valoraciones.Any(v => v.Posicion == atomo.Posicion))
-                throw new InvalidOperationException($"Ya existe una valoración para el átomo #{atomo.Posicion}");
+                throw new InvalidOperationException($"Ya existe valoración para el átomo #{atomo.Posicion}");
 
             Valoraciones.Add(atomo);
         }

--- a/src/Solver/Individuos/Individuo.cs
+++ b/src/Solver/Individuos/Individuo.cs
@@ -54,13 +54,14 @@ namespace Solver.Individuos
             List<int> cortes = [.. cromosoma.Take(cantidadCortesEsperada).Order()];
             if (cortes.First() < 0)
             {
-                string mensaje = $"Posición del primer corte no puede ser negativa: {cortes.First()}";
+                string mensaje = $"El primer corte no puede ser negativo: {cortes.First()}";
                 throw new ArgumentException(mensaje, nameof(cromosoma));
             }
 
             if (cortes.Last() > problema.CantidadAtomos)
             {
-                string mensaje = $"Posición del último corte no puede superar a {problema.CantidadAtomos}: {cortes.Last()}";
+                string mensajeTemplate = "El último corte no puede superar la cantidad de átomos ({0}): {1}";
+                string mensaje = string.Format(mensajeTemplate, problema.CantidadAtomos, cortes.Last());
                 throw new ArgumentException(mensaje, nameof(cromosoma));
             }
         }
@@ -71,14 +72,14 @@ namespace Solver.Individuos
             List<int> fueraDeRango = [.. asignaciones.Where(a => a < 1 || a > cantidadAgentes).Distinct().Order()];
             if (fueraDeRango.Count > 0)
             {
-                string mensaje = $"Hay asignaciones fuera del rango [1, {cantidadAgentes}]: ({string.Join(", ", fueraDeRango)})";
+                string mensaje = $"Hay asignaciones fuera de rango [1, {cantidadAgentes}]: ({string.Join(", ", fueraDeRango)})";
                 throw new ArgumentException(mensaje, nameof(cromosoma));
             }
 
             List<int> repetidas = asignaciones.GroupBy(a => a).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
             if (repetidas.Count > 0)
             {
-                string mensaje = $"Hay porciones asignadas a más de un agente: ({string.Join(", ", repetidas)})";
+                string mensaje = $"Hay asignaciones repetidas a agentes: ({string.Join(", ", repetidas)})";
                 throw new ArgumentException(mensaje, nameof(cromosoma));
             }
         }

--- a/tests/App.Tests/ParametrosGeneracionTests.cs
+++ b/tests/App.Tests/ParametrosGeneracionTests.cs
@@ -51,19 +51,22 @@ namespace App.Tests
         public void Constructor_RutaSalidaVacia_LanzaArgumentException(string rutaSalida)
         {
             var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, 100, rutaSalida, false));
-            Assert.StartsWith("La ruta no puede estar vacía", ex.Message);
+            Assert.Contains("no puede estar vacía", ex.Message);
             Assert.Equal("rutaSalida", ex.ParamName);
         }
 
         [Fact]
         public void Constructor_RutaSalidaInvalida_LanzaArgumentException()
         {
+            const string rutaInvalida = "¡ruta-inválida!";
+            const string mensajeExcepcionInterna = "La ruta es inválida";
+
             var fileSystemHelper = Substitute.For<FileSystemHelper>();
-            fileSystemHelper.GetFullPath("¡ruta-inválida!").Throws(new Exception("La ruta es inválida"));
+            fileSystemHelper.GetFullPath(rutaInvalida).Throws(new Exception(mensajeExcepcionInterna));
             FileSystemHelperFactory.SetearHelper(fileSystemHelper);
 
-            var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, 100, "¡ruta-inválida!", false));
-            Assert.StartsWith($"Ruta inválida: La ruta es inválida", ex.Message);
+            var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, 100, rutaInvalida, false));
+            Assert.Contains(mensajeExcepcionInterna, ex.Message);
             Assert.Equal("rutaSalida", ex.ParamName);
         }
 

--- a/tests/App.Tests/ParametrosGeneracionTests.cs
+++ b/tests/App.Tests/ParametrosGeneracionTests.cs
@@ -15,9 +15,9 @@ namespace App.Tests
         [Fact]
         public void Constructor_AtomosInvalido_LanzaArgumentOutOfRangeException()
         {
-            var excepcion = Record.Exception(() => new ParametrosGeneracion(0, 1, 100, "instancia.dat", false));
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new ParametrosGeneracion(0, 1, 100, "instancia.dat", false));
 
-            var ex = Assert.IsType<ArgumentOutOfRangeException>(excepcion);
             Assert.Contains("debe ser mayor que cero", ex.Message);
             Assert.Equal("atomos", ex.ParamName);
         }
@@ -25,9 +25,9 @@ namespace App.Tests
         [Fact]
         public void Constructor_AgentesInvalido_LanzaArgumentOutOfRangeException()
         {
-            var excepcion = Record.Exception(() => new ParametrosGeneracion(1, 0, 100, "instancia.dat", false));
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new ParametrosGeneracion(1, 0, 100, "instancia.dat", false));
 
-            var ex = Assert.IsType<ArgumentOutOfRangeException>(excepcion);
             Assert.Contains("debe ser mayor que cero", ex.Message);
             Assert.Equal("agentes", ex.ParamName);
         }
@@ -37,9 +37,9 @@ namespace App.Tests
         [InlineData(-1)]
         public void Constructor_ValorMaximoInvalido_LanzaArgumentOutOfRangeException(int valorMaximo)
         {
-            var excepcion = Record.Exception(() => new ParametrosGeneracion(1, 1, valorMaximo, "instancia.dat", false));
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new ParametrosGeneracion(1, 1, valorMaximo, "instancia.dat", false));
 
-            var ex = Assert.IsType<ArgumentOutOfRangeException>(excepcion);
             Assert.Contains("debe ser mayor que cero", ex.Message);
             Assert.Equal("valorMaximo", ex.ParamName);
         }

--- a/tests/App.Tests/ParametrosGeneracionTests.cs
+++ b/tests/App.Tests/ParametrosGeneracionTests.cs
@@ -50,9 +50,7 @@ namespace App.Tests
         [InlineData(null)]
         public void Constructor_RutaSalidaVacia_LanzaArgumentException(string rutaSalida)
         {
-            var excepcion = Record.Exception(() => new ParametrosGeneracion(1, 1, 100, rutaSalida, false));
-
-            var ex = Assert.IsType<ArgumentException>(excepcion);
+            var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, 100, rutaSalida, false));
             Assert.StartsWith("La ruta no puede estar vacía", ex.Message);
             Assert.Equal("rutaSalida", ex.ParamName);
         }
@@ -64,9 +62,7 @@ namespace App.Tests
             fileSystemHelper.GetFullPath("¡ruta-inválida!").Throws(new Exception("La ruta es inválida"));
             FileSystemHelperFactory.SetearHelper(fileSystemHelper);
 
-            var excepcion = Record.Exception(() => new ParametrosGeneracion(1, 1, 100, "¡ruta-inválida!", false));
-
-            var ex = Assert.IsType<ArgumentException>(excepcion);
+            var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, 100, "¡ruta-inválida!", false));
             Assert.StartsWith($"Ruta inválida: La ruta es inválida", ex.Message);
             Assert.Equal("rutaSalida", ex.ParamName);
         }

--- a/tests/App.Tests/ParametrosGeneracionTests.cs
+++ b/tests/App.Tests/ParametrosGeneracionTests.cs
@@ -50,7 +50,9 @@ namespace App.Tests
         [InlineData(null)]
         public void Constructor_RutaSalidaVacia_LanzaArgumentException(string rutaSalida)
         {
-            var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, 100, rutaSalida, false));
+            var excepcion = Record.Exception(() => new ParametrosGeneracion(1, 1, 100, rutaSalida, false));
+
+            var ex = Assert.IsType<ArgumentException>(excepcion);
             Assert.StartsWith("La ruta no puede estar vacía", ex.Message);
             Assert.Equal("rutaSalida", ex.ParamName);
         }
@@ -62,7 +64,9 @@ namespace App.Tests
             fileSystemHelper.GetFullPath("¡ruta-inválida!").Throws(new Exception("La ruta es inválida"));
             FileSystemHelperFactory.SetearHelper(fileSystemHelper);
 
-            var ex = Assert.Throws<ArgumentException>(() => new ParametrosGeneracion(1, 1, 100, "¡ruta-inválida!", false));
+            var excepcion = Record.Exception(() => new ParametrosGeneracion(1, 1, 100, "¡ruta-inválida!", false));
+
+            var ex = Assert.IsType<ArgumentException>(excepcion);
             Assert.StartsWith($"Ruta inválida: La ruta es inválida", ex.Message);
             Assert.Equal("rutaSalida", ex.ParamName);
         }

--- a/tests/Common.Tests/GeneradorNumerosRandomTests.cs
+++ b/tests/Common.Tests/GeneradorNumerosRandomTests.cs
@@ -5,9 +5,7 @@
         [Fact]
         public void Constructor_SemillaNegativa_LanzaArgumentOutOfRangeException()
         {
-            var excepcion = Record.Exception(() => new GeneradorNumerosRandom(-1));
-
-            var ex = Assert.IsType<ArgumentOutOfRangeException>(excepcion);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new GeneradorNumerosRandom(-1));
             Assert.Contains("no puede ser negativa", ex.Message);
             Assert.Equal("seed", ex.ParamName);
         }

--- a/tests/Generator.Tests/EscritorInstanciaTests.cs
+++ b/tests/Generator.Tests/EscritorInstanciaTests.cs
@@ -23,15 +23,15 @@ namespace Generator.Tests
         public void Constructor_FileSystemNull_LanzaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => new EscritorInstancia(null));
-            Assert.Contains("fileSystem", ex.Message);
             Assert.Equal("fileSystem", ex.ParamName);
         }
 
         [Fact]
         public void EscribirInstancia_InstanciaNull_LanzaArgumentNullException()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => _escritorInstancia.EscribirInstancia(null, NombreArchivoSalida));
-            Assert.Contains("instancia", ex.Message);
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+                _escritorInstancia.EscribirInstancia(null, NombreArchivoSalida));
+
             Assert.Equal("instancia", ex.ParamName);
         }
 
@@ -41,8 +41,10 @@ namespace Generator.Tests
         [InlineData(null)]
         public void EscribirInstancia_RutaVacia_LanzaArgumentException(string rutaInvalida)
         {
-            var ex = Assert.Throws<ArgumentException>(() => _escritorInstancia.EscribirInstancia(_instancia, rutaInvalida));
-            Assert.StartsWith("La ruta no puede estar vacía", ex.Message);
+            var ex = Assert.Throws<ArgumentException>(() =>
+                _escritorInstancia.EscribirInstancia(_instancia, rutaInvalida));
+
+            Assert.Contains("ruta no puede estar vacía", ex.Message);
             Assert.Equal("rutaArchivo", ex.ParamName);
         }
 
@@ -102,12 +104,16 @@ namespace Generator.Tests
         [Fact]
         public void EscribirInstancia_ErrorEscritura_PropagaExcepcion()
         {
+            const string mensajeExcepcionInterna = "Error de disco";
+
             _fileSystemHelper
                 .When(x => x.WriteAllLines(Arg.Any<string>(), Arg.Any<List<string>>()))
-                .Throw(new IOException("Error de disco"));
+                .Throw(new IOException(mensajeExcepcionInterna));
 
-            var ex = Assert.Throws<IOException>(() => _escritorInstancia.EscribirInstancia(_instancia, NombreArchivoSalida));
-            Assert.Equal("Error al escribir la instancia: Error de disco", ex.Message);
+            var ex = Assert.Throws<IOException>(() =>
+                _escritorInstancia.EscribirInstancia(_instancia, NombreArchivoSalida));
+
+            Assert.Contains(mensajeExcepcionInterna, ex.Message);
         }
     }
 }

--- a/tests/Generator.Tests/EscritorInstanciaTests.cs
+++ b/tests/Generator.Tests/EscritorInstanciaTests.cs
@@ -8,7 +8,7 @@ namespace Generator.Tests
         private const string DirectorioSalida = "nombreCarpeta";
         private const string NombreArchivoSalida = "instancia.dat";
 
-        private readonly decimal[,] _instancia = new decimal[1, 1] { { 1 } };
+        private readonly decimal[,] _instancia = new decimal[,] { { 1 } };
 
         private readonly FileSystemHelper _fileSystemHelper;
         private readonly EscritorInstancia _escritorInstancia;
@@ -80,7 +80,7 @@ namespace Generator.Tests
         [Fact]
         public void EscribirInstancia_InstanciaValida_EscribeContenidoCorrecto()
         {
-            _escritorInstancia.EscribirInstancia(new decimal[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } }, NombreArchivoSalida);
+            _escritorInstancia.EscribirInstancia(new decimal[,] { { 1, 2, 3 }, { 4, 5, 6 } }, NombreArchivoSalida);
 
             _fileSystemHelper.Received(1).WriteAllLines(NombreArchivoSalida, Arg.Is<List<string>>(x =>
                 x.Count == 3 &&

--- a/tests/Generator.Tests/EscritorInstanciaTests.cs
+++ b/tests/Generator.Tests/EscritorInstanciaTests.cs
@@ -22,9 +22,7 @@ namespace Generator.Tests
         [Fact]
         public void Constructor_FileSystemNull_LanzaArgumentNullException()
         {
-            var excepcion = Record.Exception(() => new EscritorInstancia(null));
-
-            var ex = Assert.IsType<ArgumentNullException>(excepcion);
+            var ex = Assert.Throws<ArgumentNullException>(() => new EscritorInstancia(null));
             Assert.Contains("fileSystem", ex.Message);
             Assert.Equal("fileSystem", ex.ParamName);
         }
@@ -32,9 +30,7 @@ namespace Generator.Tests
         [Fact]
         public void EscribirInstancia_InstanciaNull_LanzaArgumentNullException()
         {
-            var excepcion = Record.Exception(() => _escritorInstancia.EscribirInstancia(null, NombreArchivoSalida));
-
-            var ex = Assert.IsType<ArgumentNullException>(excepcion);
+            var ex = Assert.Throws<ArgumentNullException>(() => _escritorInstancia.EscribirInstancia(null, NombreArchivoSalida));
             Assert.Contains("instancia", ex.Message);
             Assert.Equal("instancia", ex.ParamName);
         }
@@ -45,9 +41,7 @@ namespace Generator.Tests
         [InlineData(null)]
         public void EscribirInstancia_RutaVacia_LanzaArgumentException(string rutaInvalida)
         {
-            var excepcion = Record.Exception(() => _escritorInstancia.EscribirInstancia(_instancia, rutaInvalida));
-
-            var ex = Assert.IsType<ArgumentException>(excepcion);
+            var ex = Assert.Throws<ArgumentException>(() => _escritorInstancia.EscribirInstancia(_instancia, rutaInvalida));
             Assert.StartsWith("La ruta no puede estar vacía", ex.Message);
             Assert.Equal("rutaArchivo", ex.ParamName);
         }
@@ -112,9 +106,7 @@ namespace Generator.Tests
                 .When(x => x.WriteAllLines(Arg.Any<string>(), Arg.Any<List<string>>()))
                 .Throw(new IOException("Error de disco"));
 
-            var excepcion = Record.Exception(() => _escritorInstancia.EscribirInstancia(_instancia, NombreArchivoSalida));
-
-            var ex = Assert.IsType<IOException>(excepcion);
+            var ex = Assert.Throws<IOException>(() => _escritorInstancia.EscribirInstancia(_instancia, NombreArchivoSalida));
             Assert.Equal("Error al escribir la instancia: Error de disco", ex.Message);
         }
     }

--- a/tests/Generator.Tests/EscritorInstanciaTests.cs
+++ b/tests/Generator.Tests/EscritorInstanciaTests.cs
@@ -22,7 +22,9 @@ namespace Generator.Tests
         [Fact]
         public void Constructor_FileSystemNull_LanzaArgumentNullException()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => new EscritorInstancia(null));
+            var excepcion = Record.Exception(() => new EscritorInstancia(null));
+
+            var ex = Assert.IsType<ArgumentNullException>(excepcion);
             Assert.Contains("fileSystem", ex.Message);
             Assert.Equal("fileSystem", ex.ParamName);
         }
@@ -30,7 +32,9 @@ namespace Generator.Tests
         [Fact]
         public void EscribirInstancia_InstanciaNull_LanzaArgumentNullException()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => _escritorInstancia.EscribirInstancia(null, NombreArchivoSalida));
+            var excepcion = Record.Exception(() => _escritorInstancia.EscribirInstancia(null, NombreArchivoSalida));
+
+            var ex = Assert.IsType<ArgumentNullException>(excepcion);
             Assert.Contains("instancia", ex.Message);
             Assert.Equal("instancia", ex.ParamName);
         }
@@ -41,7 +45,9 @@ namespace Generator.Tests
         [InlineData(null)]
         public void EscribirInstancia_RutaVacia_LanzaArgumentException(string rutaInvalida)
         {
-            var ex = Assert.Throws<ArgumentException>(() => _escritorInstancia.EscribirInstancia(_instancia, rutaInvalida));
+            var excepcion = Record.Exception(() => _escritorInstancia.EscribirInstancia(_instancia, rutaInvalida));
+
+            var ex = Assert.IsType<ArgumentException>(excepcion);
             Assert.StartsWith("La ruta no puede estar vacía", ex.Message);
             Assert.Equal("rutaArchivo", ex.ParamName);
         }
@@ -106,7 +112,9 @@ namespace Generator.Tests
                 .When(x => x.WriteAllLines(Arg.Any<string>(), Arg.Any<List<string>>()))
                 .Throw(new IOException("Error de disco"));
 
-            var ex = Assert.Throws<IOException>(() => _escritorInstancia.EscribirInstancia(_instancia, NombreArchivoSalida));
+            var excepcion = Record.Exception(() => _escritorInstancia.EscribirInstancia(_instancia, NombreArchivoSalida));
+
+            var ex = Assert.IsType<IOException>(excepcion);
             Assert.Equal("Error al escribir la instancia: Error de disco", ex.Message);
         }
     }

--- a/tests/Generator.Tests/InstanciaBuilderTests.cs
+++ b/tests/Generator.Tests/InstanciaBuilderTests.cs
@@ -25,9 +25,7 @@ namespace Generator.Tests
         [InlineData(-1)]
         public void ConCantidadDeAtomos_CantidadInvalida_LanzaArgumentOutOfRangeException(int cantidadAtomos)
         {
-            var excepcion = Record.Exception(() => _instanciaBuilder.ConCantidadDeAtomos(cantidadAtomos));
-
-            var ex = Assert.IsType<ArgumentOutOfRangeException>(excepcion);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _instanciaBuilder.ConCantidadDeAtomos(cantidadAtomos));
             Assert.Contains("debe ser mayor que cero", ex.Message);
             Assert.Equal("cantidadAtomos", ex.ParamName);
         }
@@ -37,9 +35,7 @@ namespace Generator.Tests
         [InlineData(-1)]
         public void ConCantidadDeAgentes_CantidadInvalida_LanzaArgumentOutOfRangeException(int cantidadAgentes)
         {
-            var excepcion = Record.Exception(() => _instanciaBuilder.ConCantidadDeAgentes(cantidadAgentes));
-
-            var ex = Assert.IsType<ArgumentOutOfRangeException>(excepcion);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _instanciaBuilder.ConCantidadDeAgentes(cantidadAgentes));
             Assert.Contains("debe ser mayor que cero", ex.Message);
             Assert.Equal("cantidadAgentes", ex.ParamName);
         }

--- a/tests/Generator.Tests/InstanciaBuilderTests.cs
+++ b/tests/Generator.Tests/InstanciaBuilderTests.cs
@@ -46,7 +46,7 @@ namespace Generator.Tests
         public void ConValorMaximo_CantidadInvalida_LanzaArgumentOutOfRangeException(int valorMaximo)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _instanciaBuilder.ConValorMaximo(valorMaximo));
-            Assert.StartsWith($"El valor máximo debe ser positivo: {valorMaximo}", ex.Message);
+            Assert.Contains("debe ser positivo", ex.Message);
             Assert.Equal("valorMaximo", ex.ParamName);
         }
 
@@ -54,7 +54,7 @@ namespace Generator.Tests
         public void Build_SinAtomosSeteados_LanzaInvalidOperationException()
         {
             var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder.Build);
-            Assert.Equal("Debe especificar el número de átomos antes de construir la instancia", ex.Message);
+            Assert.Contains("especificar el número de átomos", ex.Message);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Generator.Tests
                 .ConCantidadDeAtomos(2)
                 .Build);
 
-            Assert.Equal("Debe especificar el número de agentes antes de construir la instancia", ex.Message);
+            Assert.Contains("especificar el número de agentes", ex.Message);
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace Generator.Tests
                 .ConCantidadDeAgentes(2)
                 .Build);
 
-            Assert.Equal("Debe especificar el valor máximo antes de construir la instancia", ex.Message);
+            Assert.Contains("especificar el valor máximo", ex.Message);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace Generator.Tests
                 .ConValorMaximo(5)
                 .Build);
 
-            Assert.Equal("Debe especificar el tipo (disjunta o no disjunta) antes de construir la instancia", ex.Message);
+            Assert.Contains("especificar el tipo", ex.Message);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace Generator.Tests
                 .ConValoracionesDisjuntas(true)
                 .Build);
 
-            Assert.Equal("No se puede generar una instancia con más agentes que átomos si las valoraciones son disjuntas", ex.Message);
+            Assert.Contains("más agentes que átomos", ex.Message);
         }
 
         [Fact]

--- a/tests/Solver.Tests/AgenteTests.cs
+++ b/tests/Solver.Tests/AgenteTests.cs
@@ -46,7 +46,7 @@
             _agente.AgregarValoracion(new Atomo(posicion, 1));
 
             var ex = Assert.Throws<InvalidOperationException>(() => _agente.AgregarValoracion(new Atomo(posicion, 0)));
-            Assert.Equal("Ya existe valoración para el átomo", ex.Message);
+            Assert.Contains("Ya existe valoración para el átomo", ex.Message);
         }
     }
 }

--- a/tests/Solver.Tests/AgenteTests.cs
+++ b/tests/Solver.Tests/AgenteTests.cs
@@ -41,12 +41,12 @@
         [Fact]
         public void AgregarValoracion_ValoracionSobreMismoAtomo_LanzaInvalidOperationException()
         {
-            const int posicionAtomo = 1;
+            const int posicion = 1;
 
-            _agente.AgregarValoracion(new Atomo(posicionAtomo, 1));
+            _agente.AgregarValoracion(new Atomo(posicion, 1));
 
-            var ex = Assert.Throws<InvalidOperationException>(() => _agente.AgregarValoracion(new Atomo(posicionAtomo, 0)));
-            Assert.Equal($"Ya existe una valoración para el átomo #{posicionAtomo}", ex.Message);
+            var ex = Assert.Throws<InvalidOperationException>(() => _agente.AgregarValoracion(new Atomo(posicion, 0)));
+            Assert.Equal($"Ya existe una valoración para el átomo #{posicion}", ex.Message);
         }
     }
 }

--- a/tests/Solver.Tests/AgenteTests.cs
+++ b/tests/Solver.Tests/AgenteTests.cs
@@ -41,12 +41,12 @@
         [Fact]
         public void AgregarValoracion_ValoracionSobreMismoAtomo_LanzaInvalidOperationException()
         {
-            const int posicion = 1;
+            const int posicionAtomo = 1;
 
-            _agente.AgregarValoracion(new Atomo(posicion, 1));
+            _agente.AgregarValoracion(new Atomo(posicionAtomo, 1));
 
-            var ex = Assert.Throws<InvalidOperationException>(() => _agente.AgregarValoracion(new Atomo(posicion, 0)));
-            Assert.Equal($"Ya existe una valoración para el átomo #{posicion}", ex.Message);
+            var ex = Assert.Throws<InvalidOperationException>(() => _agente.AgregarValoracion(new Atomo(posicionAtomo, 0)));
+            Assert.Equal($"Ya existe una valoración para el átomo #{posicionAtomo}", ex.Message);
         }
     }
 }

--- a/tests/Solver.Tests/AgenteTests.cs
+++ b/tests/Solver.Tests/AgenteTests.cs
@@ -41,12 +41,12 @@
         [Fact]
         public void AgregarValoracion_ValoracionSobreMismoAtomo_LanzaInvalidOperationException()
         {
-            const int posicionAtomo = 1;
+            const int posicion = 1;
 
-            _agente.AgregarValoracion(new Atomo(posicionAtomo, 1));
+            _agente.AgregarValoracion(new Atomo(posicion, 1));
 
-            var ex = Assert.Throws<InvalidOperationException>(() => _agente.AgregarValoracion(new Atomo(posicionAtomo, 0)));
-            Assert.Equal($"Ya existe una valoración para el átomo #{posicionAtomo}", ex.Message);
+            var ex = Assert.Throws<InvalidOperationException>(() => _agente.AgregarValoracion(new Atomo(posicion, 0)));
+            Assert.Equal("Ya existe valoración para el átomo", ex.Message);
         }
     }
 }

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -25,9 +25,9 @@ namespace Solver.Tests
         [InlineData(-1)]
         public void Constructor_MaxGeneracionesMenorOIgualACero_LanzaArgumentOutOfRangeException(int maxGeneraciones)
         {
-            var excepcion = Record.Exception(() => new AlgoritmoGenetico(new Poblacion(), maxGeneraciones, _ => true));
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new AlgoritmoGenetico(new Poblacion(), maxGeneraciones, _ => true));
 
-            var ex = Assert.IsType<ArgumentOutOfRangeException>(excepcion);
             Assert.Contains("debe ser mayor que cero", ex.Message);
             Assert.Equal("maxGeneraciones", ex.ParamName);
         }

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -15,8 +15,7 @@ namespace Solver.Tests
         [Fact]
         public void Constructor_EsSolucionOptimaNull_LanzaArgumentNullException()
         {
-            var poblacion = Substitute.For<Poblacion>();
-            var ex = Assert.Throws<ArgumentNullException>(() => new AlgoritmoGenetico(poblacion, 10, null));
+            var ex = Assert.Throws<ArgumentNullException>(() => new AlgoritmoGenetico(new Poblacion(), 10, null));
             Assert.Equal("esSolucionOptima", ex.ParamName);
         }
 

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -6,14 +6,14 @@ namespace Solver.Tests
     public class AlgoritmoGeneticoTests
     {
         [Fact]
-        public void Constructor_PoblacionNull_ArrojaArgumentNullException()
+        public void Constructor_PoblacionNull_LanzaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => new AlgoritmoGenetico(null, 10, _ => true));
             Assert.Equal("poblacion", ex.ParamName);
         }
 
         [Fact]
-        public void Constructor_EsSolucionOptimaNull_ArrojaArgumentNullException()
+        public void Constructor_EsSolucionOptimaNull_LanzaArgumentNullException()
         {
             var poblacion = Substitute.For<Poblacion>();
             var ex = Assert.Throws<ArgumentNullException>(() => new AlgoritmoGenetico(poblacion, 10, null));

--- a/tests/Solver.Tests/AtomoTests.cs
+++ b/tests/Solver.Tests/AtomoTests.cs
@@ -7,9 +7,7 @@
         [InlineData(-1)]
         public void Constructor_PosicionMenorAUno_LanzaArgumentOutOfRangeException(int posicion)
         {
-            var excepcion = Record.Exception(() => new Atomo(posicion, 0.5m));
-
-            var ex = Assert.IsType<ArgumentOutOfRangeException>(excepcion);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new Atomo(posicion, 0.5m));
             Assert.Contains("debe ser mayor o igual a 1", ex.Message);
             Assert.Equal("posicion", ex.ParamName);
         }
@@ -17,9 +15,7 @@
         [Fact]
         public void Constructor_ValoracionNegativa_LanzaArgumentOutOfRangeException()
         {
-            var excepcion = Record.Exception(() => new Atomo(1, -0.1m));
-
-            var ex = Assert.IsType<ArgumentOutOfRangeException>(excepcion);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new Atomo(1, -0.1m));
             Assert.Contains("no puede ser negativa", ex.Message);
             Assert.Equal("valoracion", ex.ParamName);
         }

--- a/tests/Solver.Tests/Individuos/IndividuoTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoTests.cs
@@ -27,7 +27,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,] { { 1 } });
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([], instanciaProblema));
-            Assert.StartsWith("El cromosoma no puede estar vacío", ex.Message);
+            Assert.Contains("no puede estar vacío", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -39,7 +39,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([1, 2], instanciaProblema));
-            Assert.StartsWith("Cantidad de genes inválida. Esperada: 3, recibida: 2", ex.Message);
+            Assert.Contains("Cantidad de genes inválida", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -50,7 +50,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([-1, 2, 1], instanciaProblema));
-            Assert.StartsWith($"Posición del primer corte no puede ser negativa: -1", ex.Message);
+            Assert.Contains("primer corte no puede ser negativo", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -61,7 +61,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([3, 2, 1], instanciaProblema));
-            Assert.StartsWith("Posición del último corte no puede superar a 2: 3", ex.Message);
+            Assert.Contains("útlimo corte mayor a cantidad de átomos", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -84,7 +84,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, -1, 5], instanciaProblema));
-            Assert.StartsWith("Hay asignaciones fuera del rango [1, 2]: (-1, 5)", ex.Message);
+            Assert.Contains("asignaciones fuera de rango", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -101,7 +101,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([1, 2, 3, 5, 2, 0, -1], instanciaProblema));
-            Assert.StartsWith("Hay asignaciones fuera del rango [1, 4]: (-1, 0, 5)", ex.Message);
+            Assert.StartsWith("asignaciones fuera de rango", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -112,7 +112,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 1, 1], instanciaProblema));
-            Assert.StartsWith("Hay porciones asignadas a más de un agente: (1)", ex.Message);
+            Assert.Contains("porciones asignadas a más de un agente", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -129,7 +129,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 0, 4, 2, 2, 3, 3], instanciaProblema));
-            Assert.StartsWith("Hay porciones asignadas a más de un agente: (2, 3)", ex.Message);
+            Assert.Contains("porciones asignadas a más de un agente", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 

--- a/tests/Solver.Tests/Individuos/IndividuoTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoTests.cs
@@ -61,7 +61,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([3, 2, 1], instanciaProblema));
-            Assert.Contains("útlimo corte mayor a cantidad de átomos", ex.Message);
+            Assert.Contains("no puede superar la cantidad de átomos", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -73,7 +73,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 1, 0], instanciaProblema));
-            Assert.StartsWith($"Hay asignaciones fuera del rango [1, 2]: (0)", ex.Message);
+            Assert.Contains("asignaciones fuera de rango", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -101,7 +101,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([1, 2, 3, 5, 2, 0, -1], instanciaProblema));
-            Assert.StartsWith("asignaciones fuera de rango", ex.Message);
+            Assert.Contains("asignaciones fuera de rango", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -112,7 +112,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 1, 1], instanciaProblema));
-            Assert.Contains("porciones asignadas a más de un agente", ex.Message);
+            Assert.Contains("asignaciones repetidas", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 
@@ -129,7 +129,7 @@ namespace Solver.Tests.Individuos
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 0, 4, 2, 2, 3, 3], instanciaProblema));
-            Assert.Contains("porciones asignadas a más de un agente", ex.Message);
+            Assert.Contains("asignaciones repetidas", ex.Message);
             Assert.Equal("cromosoma", ex.ParamName);
         }
 

--- a/tests/Solver.Tests/Individuos/IndividuoTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoTests.cs
@@ -35,7 +35,7 @@ namespace Solver.Tests.Individuos
         public void Constructor_CantidadGenesInvalidaParaInstanciaDelProblema_LanzaArgumentException()
         {
             // Para k agentes se esperan k-1 cortes y k asignaciones
-            decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
+            decimal[,] matriz = { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([1, 2], instanciaProblema));
@@ -46,7 +46,7 @@ namespace Solver.Tests.Individuos
         [Fact]
         public void Constructor_PosicionPrimerCorteEnCromosomaEsNegativa_LanzaArgumentException()
         {
-            decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
+            decimal[,] matriz = { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([-1, 2, 1], instanciaProblema));
@@ -57,7 +57,7 @@ namespace Solver.Tests.Individuos
         [Fact]
         public void Constructor_PosicionUltimoCorteEnCromosomaEsMayorQueCantidadAtomos_LanzaArgumentException()
         {
-            decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
+            decimal[,] matriz = { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([3, 2, 1], instanciaProblema));
@@ -69,7 +69,7 @@ namespace Solver.Tests.Individuos
         public void Constructor_HayUnaAsignacionAAgentesInvalidosEnCromosoma_LanzaArgumentException()
         {
             // El rango permitido para las asignaciones de k agentes es [1, k]
-            decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
+            decimal[,] matriz = { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 1, 0], instanciaProblema));
@@ -80,7 +80,7 @@ namespace Solver.Tests.Individuos
         [Fact]
         public void Constructor_HayMasDeUnaAsignacionAAgentesInvalidosEnCromosoma_LanzaArgumentException()
         {
-            decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
+            decimal[,] matriz = { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, -1, 5], instanciaProblema));
@@ -91,7 +91,7 @@ namespace Solver.Tests.Individuos
         [Fact]
         public void Constructor_ListadoDeAsignacionesRepetidasSeMuestraOrdenadoAscendente_LanzaArgumentException()
         {
-            decimal[,] matriz = new decimal[,]
+            decimal[,] matriz =
             {
                 { 1m, 0m, 0m, 0m },
                 { 0m, 1m, 0m, 0m },
@@ -108,7 +108,7 @@ namespace Solver.Tests.Individuos
         [Fact]
         public void Constructor_HayUnaPorcionAsignadaAMasDeUnAgenteEnCromosoma_LanzaArgumentException()
         {
-            decimal[,] matriz = new decimal[,] { { 1m, 0m }, { 0m, 1m } };
+            decimal[,] matriz = { { 1m, 0m }, { 0m, 1m } };
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz);
 
             var ex = Assert.Throws<ArgumentException>(() => new IndividuoStub([0, 1, 1], instanciaProblema));
@@ -119,7 +119,7 @@ namespace Solver.Tests.Individuos
         [Fact]
         public void Constructor_HayMasDeUnaPorcionAsignadaAMasDeUnAgenteEnCromosoma_LanzaArgumentException()
         {
-            decimal[,] matriz = new decimal[,]
+            decimal[,] matriz =
             {
                 { 1m, 0m, 0m, 0m },
                 { 0m, 1m, 0m, 0m },

--- a/tests/Solver.Tests/InstanciaProblemaTests.cs
+++ b/tests/Solver.Tests/InstanciaProblemaTests.cs
@@ -21,10 +21,7 @@
         [Fact]
         public void CrearDesdeMatrizDeValoraciones_MatrizConAgentesSinValoraciones_LanzaArgumentException()
         {
-            decimal[,] matriz = {
-                { 0, 1, 1 },
-                { 0, 1, 1 },
-            };
+            decimal[,] matriz = { { 0, 1, 1 }, { 0, 1, 1 }, };
             var ex = Assert.Throws<ArgumentException>(() => InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz));
             Assert.Contains("no tiene valoraciones positivas", ex.Message);
             Assert.Equal("matrizValoraciones", ex.ParamName);

--- a/tests/Solver.Tests/InstanciaProblemaTests.cs
+++ b/tests/Solver.Tests/InstanciaProblemaTests.cs
@@ -14,7 +14,7 @@
         {
             var matriz = new decimal[0, 0];
             var ex = Assert.Throws<ArgumentException>(() => InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz));
-            Assert.StartsWith("La matriz de valoraciones no puede estar vacía", ex.Message);
+            Assert.Contains("no puede estar vacía", ex.Message);
             Assert.Equal("matrizValoraciones", ex.ParamName);
         }
 
@@ -26,7 +26,7 @@
                 { 0, 1, 1 },
             };
             var ex = Assert.Throws<ArgumentException>(() => InstanciaProblema.CrearDesdeMatrizDeValoraciones(matriz));
-            Assert.StartsWith("El agente 1 no tiene valoraciones positivas sobre ningún átomo", ex.Message);
+            Assert.Contains("no tiene valoraciones positivas", ex.Message);
             Assert.Equal("matrizValoraciones", ex.ParamName);
         }
 

--- a/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
+++ b/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
@@ -20,14 +20,14 @@ namespace Solver.Tests
         }
 
         [Fact]
-        public void Constructor_FileSystemHelperNull_ArrojaArgumentNullException()
+        public void Constructor_FileSystemHelperNull_LanzaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => new LectorArchivoMatrizValoraciones(null));
             Assert.Equal("fileSystemHelper", ex.ParamName);
         }
 
         [Fact]
-        public void Leer_RutaNull_ArrojaArgumentNullException()
+        public void Leer_RutaNull_LanzaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => _lector.Leer(null));
             Assert.Equal("rutaArchivo", ex.ParamName);
@@ -37,7 +37,7 @@ namespace Solver.Tests
         [InlineData("")]
         [InlineData(" ")]
         [InlineData("rutaArchivo.txt")]
-        public void Leer_ArchivoNoExistente_ArrojaArgumentException(string rutaArchivo)
+        public void Leer_ArchivoNoExistente_LanzaArgumentException(string rutaArchivo)
         {
             _fileSystemHelper.FileExists(rutaArchivo).Returns(false);
 
@@ -47,7 +47,7 @@ namespace Solver.Tests
         }
 
         [Fact]
-        public void Leer_ArchivoVacio_ArrojaFormatException()
+        public void Leer_ArchivoVacio_LanzaFormatException()
         {
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([]);
 
@@ -59,7 +59,7 @@ namespace Solver.Tests
         [InlineData("")]
         [InlineData("1")]
         [InlineData("1 2 3")]
-        public void Leer_PrimeraLineaConFormatoIncorrecto_ArrojaFormatException(string primeraLinea)
+        public void Leer_PrimeraLineaConFormatoIncorrecto_LanzaFormatException(string primeraLinea)
         {
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
@@ -71,7 +71,7 @@ namespace Solver.Tests
         [InlineData("@ 1", "@")]
         [InlineData("1.1 1", "1.1")]
         [InlineData("Algo 2", "Algo")]
-        public void Leer_CantidadFilasInvalida_ArrojaFormatException(string primeraLinea, string valorFilas)
+        public void Leer_CantidadFilasInvalida_LanzaFormatException(string primeraLinea, string valorFilas)
         {
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
@@ -82,7 +82,7 @@ namespace Solver.Tests
         [Theory]
         [InlineData("1 @", "@")]
         [InlineData("2 Algo", "Algo")]
-        public void Leer_CantidadColumnasInvalida_ArrojaFormatException(string primeraLinea, string valorColumnas)
+        public void Leer_CantidadColumnasInvalida_LanzaFormatException(string primeraLinea, string valorColumnas)
         {
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
@@ -91,7 +91,7 @@ namespace Solver.Tests
         }
 
         [Fact]
-        public void Leer_NumeroFilasEsperadasNoCoincideConEncontradas_ArrojaFormatException()
+        public void Leer_NumeroFilasEsperadasNoCoincideConEncontradas_LanzaFormatException()
         {
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["1 3", "1\t2\t3", "4\t5\t6"]);
 
@@ -103,7 +103,7 @@ namespace Solver.Tests
         [InlineData("", "4\t5\t6", "7\t8\t9", 0, 1)]
         [InlineData("1\t2\t3", "4\t5", "7\t8\t9", 1, 2)]
         [InlineData("1\t2\t3", "4\t5\t6", "7\t8\t9\t0", 2, 4)]
-        public void Leer_NumeroColumnasEsperadasNoCoincideConEncontradas_ArrojaFormatException(
+        public void Leer_NumeroColumnasEsperadasNoCoincideConEncontradas_LanzaFormatException(
             string fila0, string fila1, string fila2, int filaConError, int columnasEncontradas)
         {
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["3 3", fila0, fila1, fila2]);
@@ -115,7 +115,7 @@ namespace Solver.Tests
         [Theory]
         [InlineData("@\t2\t3", "4\t5\t6", "@", 0, 0)]
         [InlineData("1\t2\t3", "4\t5\tAlgo", "Algo", 1, 2)]
-        public void Leer_CeldaConValorInvalido_ArrojaFormatException(
+        public void Leer_CeldaConValorInvalido_LanzaFormatException(
             string fila0, string fila1, string valorInvalido, int filaConError, int columnaConError)
         {
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["2 3", fila0, fila1]);
@@ -127,7 +127,7 @@ namespace Solver.Tests
         [Theory]
         [InlineData("4.4\t5.5\t6.6")]
         [InlineData("   4.4\t5.5\t6.6   ")]
-        public void Leer_ArchivoValido_NoArrojaExcepciones(string fila1)
+        public void Leer_ArchivoValido_NoLanzaExcepciones(string fila1)
         {
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["2 3", "1.1\t2.2\t3.3", fila1]);
 

--- a/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
+++ b/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
@@ -42,7 +42,7 @@ namespace Solver.Tests
             _fileSystemHelper.FileExists(rutaArchivo).Returns(false);
 
             var ex = Assert.Throws<ArgumentException>(() => _lector.Leer(rutaArchivo));
-            Assert.StartsWith($"No existe el archivo '{rutaArchivo}'", ex.Message);
+            Assert.Contains("No existe el archivo", ex.Message);
             Assert.Equal("rutaArchivo", ex.ParamName);
         }
 
@@ -52,7 +52,7 @@ namespace Solver.Tests
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([]);
 
             var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
-            Assert.Equal("El archivo está vacío o tiene un formato inválido", ex.Message);
+            Assert.Contains("está vacío o tiene un formato inválido", ex.Message);
         }
 
         [Theory]
@@ -64,7 +64,7 @@ namespace Solver.Tests
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
             var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
-            Assert.Equal("La primera línea debe contener las dimensiones en formato '#filas #columnas'", ex.Message);
+            Assert.Contains("debe contener las dimensiones en formato '#filas #columnas'", ex.Message);
         }
 
         [Theory]
@@ -76,7 +76,7 @@ namespace Solver.Tests
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
             var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
-            Assert.StartsWith($"El valor indicado para filas no es numérico: {valorFilas}", ex.Message);
+            Assert.Contains("no es numérico", ex.Message);
         }
 
         [Theory]
@@ -87,7 +87,7 @@ namespace Solver.Tests
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
             var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
-            Assert.StartsWith($"El valor indicado para columnas no es numérico: {valorColumnas}", ex.Message);
+            Assert.StartsWith("no es numérico", ex.Message);
         }
 
         [Fact]
@@ -96,7 +96,8 @@ namespace Solver.Tests
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["1 3", "1\t2\t3", "4\t5\t6"]);
 
             var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
-            Assert.Equal("Filas esperadas: 1, encontradas: 2", ex.Message);
+            Assert.Contains("Filas esperadas", ex.Message);
+            Assert.Contains("encontradas", ex.Message);
         }
 
         [Theory]
@@ -109,19 +110,22 @@ namespace Solver.Tests
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["3 3", fila0, fila1, fila2]);
 
             var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
-            Assert.StartsWith($"Fila {filaConError}, columnas esperadas: 3, encontradas: {columnasEncontradas}", ex.Message);
+
+            Assert.Contains($"Fila {filaConError}", ex.Message);
+            Assert.Contains("columnas esperadas", ex.Message);
+            Assert.Contains($"encontradas: {columnasEncontradas}", ex.Message);
         }
 
         [Theory]
-        [InlineData("@\t2\t3", "4\t5\t6", "@", 0, 0)]
-        [InlineData("1\t2\t3", "4\t5\tAlgo", "Algo", 1, 2)]
+        [InlineData("@\t2\t3", "4\t5\t6")]
+        [InlineData("1\t2\t3", "4\t5\tAlgo")]
         public void Leer_CeldaConValorInvalido_LanzaFormatException(
-            string fila0, string fila1, string valorInvalido, int filaConError, int columnaConError)
+            string fila0, string fila1)
         {
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["2 3", fila0, fila1]);
 
             var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
-            Assert.Equal($"Valor inválido '{valorInvalido}' en ({filaConError}, {columnaConError})", ex.Message);
+            Assert.Equal("Valor inválido", ex.Message);
         }
 
         [Theory]

--- a/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
+++ b/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
@@ -87,7 +87,7 @@ namespace Solver.Tests
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
             var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
-            Assert.StartsWith("no es numérico", ex.Message);
+            Assert.Contains("no es numérico", ex.Message);
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace Solver.Tests
             _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["2 3", fila0, fila1]);
 
             var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
-            Assert.Equal("Valor inválido", ex.Message);
+            Assert.Contains("Valor inválido", ex.Message);
         }
 
         [Theory]


### PR DESCRIPTION
En este PR se modificaron tests para cumplir con algunas convenciones. Entre ellas están:

- Validar en el mensaje solo la parte que describe la regla de negocio, no el mensaje completo.
- Incluir el tipo de excepción esperada en el nombre del método de test, usando `_LanzaTipoExcepcion`.
- Usar `Assert.Throws<>` para validar excepciones en los tests.