### PR TITLE
style(resolver-command): corrección de typo en comentario

### DIFF
--- a/src/App/ResolverCommand.cs
+++ b/src/App/ResolverCommand.cs
@@ -37,7 +37,7 @@ namespace App
             var poblacion = new Poblacion(parametros.TamañoPoblacion);
             // TODO: instanciar algoritmo genético
             // TODO: ejecutar algoritmo genético
-            // TODO: devoler resultado
+            // TODO: devolver resultado
         }
     }
 }


### PR DESCRIPTION
Este pull request corrige un typo en un comentario del método `Handler` en `src/App/ResolverCommand.cs`: se cambió "devoler" por "devolver".