### PR TITLE
fix(individuos): validar cortes sin duplicar condiciones

### DIFF
--- a/src/Solver/Individuos/Individuo.cs
+++ b/src/Solver/Individuos/Individuo.cs
@@ -88,6 +88,10 @@ namespace Solver.Individuos
         private void ValidarCortes(List<int> cromosoma, InstanciaProblema problema, int cantidadCortesEsperada)
         {
             List<int> cortes = [.. cromosoma.Take(cantidadCortesEsperada).Order()];
+
+            if (cantidadCortesEsperada == 0 || cortes.Count == 0)
+                return;
+
             if (cortes.First() < 0)
             {
                 string mensaje = $"El primer corte no puede ser negativo: {cortes.First()}";

--- a/tests/Solver.Tests/Individuos/IndividuoTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoTests.cs
@@ -156,14 +156,13 @@ namespace Solver.Tests.Individuos
         [Fact]
         public void Constructor_CromosomaValidoParaUnAgente_NoLanzaExcepciones()
         {
-            var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,]
-            {
-                { 1m }
-            });
+            // 1ra porción se asigna al agente 1
+            var cromosomaValido = new List<int> { 1 };
 
-            var cromosoma = new List<int> { 1 };
+            // 1 átomo, 1 agente
+            var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,] { { 1m } });
 
-            var ex = Record.Exception(() => new IndividuoStub(cromosoma, instanciaProblema));
+            var ex = Record.Exception(() => new IndividuoStub(cromosomaValido, instanciaProblema));
             Assert.Null(ex);
         }
 

--- a/tests/Solver.Tests/Individuos/IndividuoTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoTests.cs
@@ -154,6 +154,20 @@ namespace Solver.Tests.Individuos
         }
 
         [Fact]
+        public void Constructor_CromosomaValidoParaUnAgente_NoLanzaExcepciones()
+        {
+            var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,]
+            {
+                { 1m }
+            });
+
+            var cromosoma = new List<int> { 1 };
+
+            var ex = Record.Exception(() => new IndividuoStub(cromosoma, instanciaProblema));
+            Assert.Null(ex);
+        }
+
+        [Fact]
         public void ExtraerAsignacion_AsignacionEstandar_DevuelveAtomosCorrectos()
         {
             var problema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,]


### PR DESCRIPTION
Este PR mejora la validación en la clase `Individuo` para manejar correctamente casos en los que la cantidad esperada de cortes es cero, evitando errores en la construcción de cromosomas para escenarios de un solo agente.