### PR TITLE
feat(generador-numeros-random): se agregó método Siguiente solo con límite máximo

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -2,13 +2,14 @@
 
 ## Commits
 
-- Mensajes en español, usando estructura impersonal y pretérito perfecto simple.  
+- Mensajes en español, usando estructura impersonal y pretérito perfecto simple. No se debe usar verbos en infinitivo.
   Ejemplo: `se agregó función para validar usuarios`, `se eliminó archivo obsoleto`.
 
 ## Pull Requests
 
-- Títulos bajo convención Angular:  
-  `tipo(ámbito): descripción`
+### Título
+
+- Usar convención Angular: `tipo(ámbito): descripción`
 - Tipos permitidos:
   - `feat(ámbito):` Nueva funcionalidad
   - `fix(ámbito):` Corrección de errores
@@ -19,29 +20,47 @@
   - `style(ámbito):` Cambios de formato/código
   - `perf(ámbito):` Mejoras de performance
   - `ci(ámbito):` Cambios en CI/CD
+- La "descripción" del título debe estar escrita en español, usando estructura impersonal y pretérito perfecto
+  simple, igual que los mensajes de commit. No usar infinitivo.
 
-- Descripciones en estructura impersonal, igual que los commits.
+Ejemplo: `feat(usuario): se agregó validación de email`
+
+### Ámbito
+
+- El ámbito identifica el área, módulo, carpeta, funcionalidad o clase específica del sistema afectada por el cambio.
+- Si es un cambio global se puede usar `proyecto` o `solución`.
+- Si corresponde a una clase, se utiliza el nombre de la clase tal como está en el código, en minúsculas y sin espacios.
+- Para clases con nombres compuestos, se puede separar con guiones para mayor claridad.
+- Ejemplos: `usuario`, `login`, `proyecto`, `solución`, `config`, `usuario-controller`, `validador-email`.
+
+### Descripción
+
+- Escribir la descripción del PR en estructura impersonal, igual que los commits.
 - La descripción debe iniciar con `En este PR...` seguida de los cambios realizados.
-- No se debe incluir el enlace a la task de Codex.
+- En la descripción del PR se puede volver a mencionar el ámbito para dejar claro qué parte del sistema fue modificada.
+- Ejemplo:
+  ```text
+  En este PR se implementó la validación de email del usuario.
+  Se agregó una nueva clase `ValidadorEmail` que verifica el formato del email ingresado.
+  ```
 
 ## Nombres de ramas
 
 - Formatos válidos:
-  - `tipo/descripcion-breve`
-  - `tipo/ámbito/descripcion-breve`
+  - `tipo/nombre-de-feature`
+  - `tipo/ámbito/nombre-de-feature`
+- No usar tildes ni caracteres con acentos.
 
 ## Código
 
-- Interfaces y clases con nombres en español.
 - Código siempre en español.
 - No lanzar excepciones desde constructores.
 - Controladores: sin lógica, solo pasamanos.
-- No incluir comentarios `arrange`, `act`, `assert` en tests.
 
 ## Tests
 
 - Nombres de tests:
   - `MetodoBajoPrueba_CasoOEstadoBajoPrueba_ComportamientoEsperado`
   - `MetodoBajoPrueba_ComportamientoEsperado`
-- Solo se testean métodos públicos.  
-  Métodos privados se cubren indirectamente a través de los públicos.
+- Solo se testean métodos públicos. Métodos privados se cubren indirectamente a través de los públicos.
+- No incluir comentarios `arrange`, `act`, `assert`.

--- a/src/Common/GeneradorNumerosRandom.cs
+++ b/src/Common/GeneradorNumerosRandom.cs
@@ -22,6 +22,11 @@
             return _random.Next();
         }
 
+        public virtual int Siguiente(int maximo)
+        {
+            return _random.Next(maximo);
+        }
+
         public virtual int Siguiente(int minimo, int maximo)
         {
             return _random.Next(minimo, maximo);

--- a/src/Generator/InstanciaBuilder.cs
+++ b/src/Generator/InstanciaBuilder.cs
@@ -95,8 +95,8 @@ namespace Generator
 
             while (agentesDisponibles.Count > 0)
             {
-                int indiceAtomo = _generadorNumerosRandom.Siguiente(0, atomosDisponibles.Count);
-                int indiceAgente = _generadorNumerosRandom.Siguiente(0, agentesDisponibles.Count);
+                int indiceAtomo = _generadorNumerosRandom.Siguiente(atomosDisponibles.Count);
+                int indiceAgente = _generadorNumerosRandom.Siguiente(agentesDisponibles.Count);
 
                 int atomoElegido = atomosDisponibles[indiceAtomo];
                 int agenteElegido = agentesDisponibles[indiceAgente];
@@ -108,8 +108,8 @@ namespace Generator
 
             while (atomosDisponibles.Count > 0)
             {
-                int indiceAtomo = _generadorNumerosRandom.Siguiente(0, atomosDisponibles.Count);
-                int agenteElegido = _generadorNumerosRandom.Siguiente(0, _cantidadAgentes);
+                int indiceAtomo = _generadorNumerosRandom.Siguiente(atomosDisponibles.Count);
+                int agenteElegido = _generadorNumerosRandom.Siguiente(_cantidadAgentes);
                 int atomoElegido = atomosDisponibles[indiceAtomo];
 
                 instancia[atomoElegido, agenteElegido] = _generadorNumerosRandom.Siguiente(1, _valorMaximo + 1);

--- a/src/Solver/Poblacion.cs
+++ b/src/Solver/Poblacion.cs
@@ -60,8 +60,8 @@ namespace Solver
 
         private Individuo SeleccionarIndividuoPorTorneo()
         {
-            int indice1 = _random.Siguiente(0, Individuos.Count);
-            int indice2 = _random.Siguiente(0, Individuos.Count);
+            int indice1 = _random.Siguiente(Individuos.Count);
+            int indice2 = _random.Siguiente(Individuos.Count);
 
             Individuo resultado = Individuos[indice1].Fitness <= Individuos[indice2].Fitness
                 ? Individuos[indice1] : Individuos[indice2];

--- a/tests/Common.Tests/GeneradorNumerosRandomTests.cs
+++ b/tests/Common.Tests/GeneradorNumerosRandomTests.cs
@@ -41,5 +41,13 @@
             int numero = generador.Siguiente(1, 100);
             Assert.InRange(numero, 1, 99);
         }
+
+        [Fact]
+        public void Siguiente_ConMaximo_DevuelveNumeroEnRango()
+        {
+            var generador = new GeneradorNumerosRandom();
+            int numero = generador.Siguiente(100);
+            Assert.InRange(numero, 0, 99);
+        }
     }
 }

--- a/tests/Generator.Tests/InstanciaBuilderTests.cs
+++ b/tests/Generator.Tests/InstanciaBuilderTests.cs
@@ -144,7 +144,7 @@ namespace Generator.Tests
         public void Build_ValoracionesDisjuntas_CadaFilaTieneUnSoloValorPositivo()
         {
             var generadorNumerosRandom = Substitute.For<GeneradorNumerosRandom>();
-            generadorNumerosRandom.Siguiente(Arg.Any<int>(), Arg.Any<int>()).Returns(0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0, 4);
+            generadorNumerosRandom.Siguiente(Arg.Any<int>(), Arg.Any<int>()).Returns(1, 2, 3, 4);
 
             decimal[,] instancia = new InstanciaBuilder(generadorNumerosRandom)
                 .ConCantidadDeAtomos(4)
@@ -174,7 +174,7 @@ namespace Generator.Tests
         public void Build_UnSoloAgenteValoracionesDisjuntas_AsignaTodaLaColumnaAlAgente()
         {
             var generadorNumerosRandom = Substitute.For<GeneradorNumerosRandom>();
-            generadorNumerosRandom.Siguiente(Arg.Any<int>(), Arg.Any<int>()).Returns(0, 0, 1, 0, 0, 2, 0, 0, 3);
+            generadorNumerosRandom.Siguiente(Arg.Any<int>(), Arg.Any<int>()).Returns(1, 2, 3);
 
             decimal[,] instancia = new InstanciaBuilder(generadorNumerosRandom)
                 .ConCantidadDeAtomos(3)

--- a/tests/Generator.Tests/InstanciaBuilderTests.cs
+++ b/tests/Generator.Tests/InstanciaBuilderTests.cs
@@ -144,6 +144,7 @@ namespace Generator.Tests
         public void Build_ValoracionesDisjuntas_CadaFilaTieneUnSoloValorPositivo()
         {
             var generadorNumerosRandom = Substitute.For<GeneradorNumerosRandom>();
+            generadorNumerosRandom.Siguiente(Arg.Any<int>()).Returns(0);
             generadorNumerosRandom.Siguiente(Arg.Any<int>(), Arg.Any<int>()).Returns(1, 2, 3, 4);
 
             decimal[,] instancia = new InstanciaBuilder(generadorNumerosRandom)
@@ -174,6 +175,7 @@ namespace Generator.Tests
         public void Build_UnSoloAgenteValoracionesDisjuntas_AsignaTodaLaColumnaAlAgente()
         {
             var generadorNumerosRandom = Substitute.For<GeneradorNumerosRandom>();
+            generadorNumerosRandom.Siguiente(Arg.Any<int>()).Returns(0);
             generadorNumerosRandom.Siguiente(Arg.Any<int>(), Arg.Any<int>()).Returns(1, 2, 3);
 
             decimal[,] instancia = new InstanciaBuilder(generadorNumerosRandom)

--- a/tests/Solver.Tests/PoblacionTests.cs
+++ b/tests/Solver.Tests/PoblacionTests.cs
@@ -62,7 +62,7 @@ namespace Solver.Tests
             int tamaño = 2, indicePadre1 = 0, indicePadre2 = 1;
 
             var random = Substitute.For<GeneradorNumerosRandom>();
-            random.Siguiente(0, tamaño).Returns(indicePadre1, indicePadre2);
+            random.Siguiente(tamaño).Returns(indicePadre1, indicePadre2);
             GeneradorNumerosRandomFactory.SetearGenerador(random);
 
             var poblacion = new Poblacion(tamaño);
@@ -76,7 +76,7 @@ namespace Solver.Tests
         public void GenerarNuevaGeneracion_Hijos_Mutan()
         {
             var random = Substitute.For<GeneradorNumerosRandom>();
-            random.Siguiente(Arg.Any<int>(), Arg.Any<int>()).Returns(0, 1);
+            random.Siguiente(Arg.Any<int>()).Returns(0, 1);
             GeneradorNumerosRandomFactory.SetearGenerador(random);
 
             Individuo padre = CrearIndividuoFake(fitness: 5);


### PR DESCRIPTION
En este PR se implementó un nuevo método en **GeneradorNumerosRandom** que permite obtener un número aleatorio desde cero hasta un límite superior. Además, se reemplazaron las llamadas que utilizaban el rango con cero como mínimo por este nuevo método y se adaptaron las pruebas unitarias correspondientes.