### PR TITLE
feat(algoritmo-genetico): se permite ejecución indefinida cuando maxGeneraciones es cero

### DIFF
--- a/src/Solver/AlgoritmoGenetico.cs
+++ b/src/Solver/AlgoritmoGenetico.cs
@@ -13,9 +13,9 @@ namespace Solver
             ArgumentNullException.ThrowIfNull(poblacion, nameof(poblacion));
             ArgumentNullException.ThrowIfNull(esSolucionOptima, nameof(esSolucionOptima));
 
-            if (maxGeneraciones <= 0)
+            if (maxGeneraciones < 0)
             {
-                string mensaje = "El número máximo de generaciones debe ser mayor que cero.";
+                string mensaje = "El número máximo de generaciones no puede ser negativo.";
                 throw new ArgumentOutOfRangeException(nameof(maxGeneraciones), mensaje);
             }
 
@@ -26,6 +26,20 @@ namespace Solver
 
         internal Individuo Ejecutar()
         {
+            if (_maxGeneraciones == 0)
+            {
+                while (true)
+                {
+                    foreach (Individuo individuo in _poblacion.Individuos)
+                    {
+                        if (_esSolucionOptima(individuo))
+                            return individuo;
+                    }
+
+                    _poblacion = _poblacion.GenerarNuevaGeneracion();
+                }
+            }
+
             for (int generacion = 0; generacion < _maxGeneraciones; generacion++)
             {
                 foreach (Individuo individuo in _poblacion.Individuos)

--- a/src/Solver/AlgoritmoGenetico.cs
+++ b/src/Solver/AlgoritmoGenetico.cs
@@ -26,21 +26,11 @@ namespace Solver
 
         internal Individuo Ejecutar()
         {
-            if (_maxGeneraciones == 0)
-            {
-                while (true)
-                {
-                    foreach (Individuo individuo in _poblacion.Individuos)
-                    {
-                        if (_esSolucionOptima(individuo))
-                            return individuo;
-                    }
+            int generacion = 0;
+            bool ejecutarHastaEncontrarSolucion = _maxGeneraciones == 0;
+            bool generacionLimiteNoAlcanzada = generacion < _maxGeneraciones;
 
-                    _poblacion = _poblacion.GenerarNuevaGeneracion();
-                }
-            }
-
-            for (int generacion = 0; generacion < _maxGeneraciones; generacion++)
+            while (ejecutarHastaEncontrarSolucion || generacionLimiteNoAlcanzada)
             {
                 foreach (Individuo individuo in _poblacion.Individuos)
                 {
@@ -49,6 +39,7 @@ namespace Solver
                 }
 
                 _poblacion = _poblacion.GenerarNuevaGeneracion();
+                generacionLimiteNoAlcanzada = ++generacion < _maxGeneraciones;
             }
 
             Individuo mejorIndividuo = _poblacion.ObtenerMejorIndividuo();

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -106,16 +106,14 @@ namespace Solver.Tests
         [Fact]
         public void Ejecutar_MaxGeneracionesCero_EjecutaHastaEncontrarSolucion()
         {
-            var individuoNoOptimo = CrearIndividuoFake();
-            var individuoOptimo = CrearIndividuoFake();
+            Individuo individuoOptimo = CrearIndividuoFake();
 
             var poblacionInicial = Substitute.For<Poblacion>(1);
+            poblacionInicial.Individuos.Returns([CrearIndividuoFake()]);
+
             var poblacionSiguiente = Substitute.For<Poblacion>(1);
-
-            poblacionInicial.Individuos.Returns([individuoNoOptimo]);
-            poblacionInicial.GenerarNuevaGeneracion().Returns(poblacionSiguiente);
-
             poblacionSiguiente.Individuos.Returns([individuoOptimo]);
+            poblacionInicial.GenerarNuevaGeneracion().Returns(poblacionSiguiente);
 
             var algoritmo = new AlgoritmoGenetico(poblacionInicial, 0, i => i == individuoOptimo);
             Individuo resultado = algoritmo.Ejecutar();

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -20,14 +20,13 @@ namespace Solver.Tests
         }
 
         [Theory]
-        [InlineData(0)]
         [InlineData(-1)]
-        public void Constructor_MaxGeneracionesMenorOIgualACero_LanzaArgumentOutOfRangeException(int maxGeneraciones)
+        public void Constructor_MaxGeneracionesNegativo_LanzaArgumentOutOfRangeException(int maxGeneraciones)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new AlgoritmoGenetico(new Poblacion(1), maxGeneraciones, _ => true));
 
-            Assert.Contains("debe ser mayor que cero", ex.Message);
+            Assert.Contains("no puede ser negativo", ex.Message);
             Assert.Equal("maxGeneraciones", ex.ParamName);
         }
 
@@ -102,6 +101,28 @@ namespace Solver.Tests
 
             poblacion.Received(1).GenerarNuevaGeneracion();
             nuevaPoblacion.Received(1).GenerarNuevaGeneracion();
+        }
+
+        [Fact]
+        public void Ejecutar_MaxGeneracionesCero_EjecutaHastaEncontrarSolucion()
+        {
+            var individuoNoOptimo = CrearIndividuoFake();
+            var individuoOptimo = CrearIndividuoFake();
+
+            var poblacionInicial = Substitute.For<Poblacion>(1);
+            var poblacionSiguiente = Substitute.For<Poblacion>(1);
+
+            poblacionInicial.Individuos.Returns([individuoNoOptimo]);
+            poblacionInicial.GenerarNuevaGeneracion().Returns(poblacionSiguiente);
+
+            poblacionSiguiente.Individuos.Returns([individuoOptimo]);
+
+            var algoritmo = new AlgoritmoGenetico(poblacionInicial, 0, i => i == individuoOptimo);
+            Individuo resultado = algoritmo.Ejecutar();
+
+            Assert.Same(individuoOptimo, resultado);
+            poblacionInicial.Received(1).GenerarNuevaGeneracion();
+            poblacionSiguiente.DidNotReceive().GenerarNuevaGeneracion();
         }
 
         [Fact]


### PR DESCRIPTION
En este PR se modificó `AlgoritmoGenetico` para que `maxGeneraciones` pueda ser cero y, en ese caso, el algoritmo ejecute sin límite hasta hallar una solución. Se actualizaron las pruebas unitarias para validar esta nueva lógica.