### PR TITLE
feat(solver): remoción de interface `ICalculadoraFitness`

### DIFF
--- a/src/Solver/Fitness/ICalculadoraFitness.cs
+++ b/src/Solver/Fitness/ICalculadoraFitness.cs
@@ -1,9 +1,0 @@
-﻿using Solver.Individuos;
-
-namespace Solver.Fitness
-{
-    internal interface ICalculadoraFitness
-    {
-        decimal CalcularFitness(Individuo individuo, InstanciaProblema instanciaProblema);
-    }
-}

--- a/src/Solver/Individuos/CalculadoraFitness.cs
+++ b/src/Solver/Individuos/CalculadoraFitness.cs
@@ -1,8 +1,6 @@
-﻿using Solver.Individuos;
-
-namespace Solver.Fitness
+namespace Solver.Individuos
 {
-    internal class CalculadorEnvyFreeness : ICalculadoraFitness
+    internal class CalculadoraFitness
     {
         public decimal CalcularFitness(Individuo individuo, InstanciaProblema problema)
         {

--- a/src/Solver/Individuos/Individuo.cs
+++ b/src/Solver/Individuos/Individuo.cs
@@ -1,19 +1,20 @@
-﻿using Solver.Fitness;
-
 namespace Solver.Individuos
 {
     internal abstract class Individuo
     {
         protected readonly List<int> _cromosoma;
         protected readonly InstanciaProblema _problema;
+        protected readonly CalculadoraFitness _calculadoraFitness;
 
-        protected Individuo(List<int> cromosoma, InstanciaProblema problema)
+        protected Individuo(List<int> cromosoma, InstanciaProblema problema, CalculadoraFitness calculadoraFitness)
         {
             ArgumentNullException.ThrowIfNull(cromosoma, nameof(cromosoma));
             ArgumentNullException.ThrowIfNull(problema, nameof(problema));
+            ArgumentNullException.ThrowIfNull(calculadoraFitness, nameof(calculadoraFitness));
 
             _cromosoma = cromosoma;
             _problema = problema;
+            _calculadoraFitness = calculadoraFitness;
 
             if (cromosoma.Count == 0)
                 throw new ArgumentException("El cromosoma no puede estar vacío", nameof(cromosoma));
@@ -25,7 +26,6 @@ namespace Solver.Individuos
 
         internal abstract void Mutar();
         internal abstract Individuo Cruzar(Individuo otro);
-        internal abstract void CalcularFitness(ICalculadoraFitness calculadoraFitness);
 
         internal List<Agente> ExtraerAsignacion()
         {

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -155,7 +155,7 @@ namespace Solver.Tests
                 { 0m, 1m },
                 { 0m, 1m },
             });
-            var individuo = Substitute.For<Individuo>(new List<int> { 1, 1, 2 }, instanciaProblema);
+            var individuo = Substitute.For<Individuo>(new List<int> { 1, 1, 2 }, instanciaProblema, new CalculadoraFitness());
             return individuo;
         }
     }

--- a/tests/Solver.Tests/Individuos/CalculadoraFitnessTests.cs
+++ b/tests/Solver.Tests/Individuos/CalculadoraFitnessTests.cs
@@ -1,11 +1,10 @@
-﻿using Solver.Fitness;
 using Solver.Individuos;
 
-namespace Solver.Tests.Fitness
+namespace Solver.Tests.Individuos
 {
-    public class CalculadorEnvyFreenessTests
+    public class CalculadoraFitnessTests
     {
-        private readonly CalculadorEnvyFreeness _calculador = new();
+        private readonly CalculadoraFitness _calculadora = new();
 
         [Fact]
         public void CalcularFitness_AsignacionSinEnvidia_RetornaCero()
@@ -18,7 +17,7 @@ namespace Solver.Tests.Fitness
             var cromosoma = new List<int> { 1, 1, 2 };
             var individuo = new IndividuoStub(cromosoma, problema);
 
-            decimal fitness = _calculador.CalcularFitness(individuo, problema);
+            decimal fitness = _calculadora.CalcularFitness(individuo, problema);
             Assert.Equal(0, fitness);
         }
 
@@ -33,7 +32,7 @@ namespace Solver.Tests.Fitness
             var cromosoma = new List<int> { 1, 2, 1 };
             var individuo = new IndividuoStub(cromosoma, problema);
 
-            decimal fitness = _calculador.CalcularFitness(individuo, problema);
+            decimal fitness = _calculadora.CalcularFitness(individuo, problema);
             Assert.True(fitness > 0);
         }
 
@@ -49,13 +48,14 @@ namespace Solver.Tests.Fitness
             var cromosoma = new List<int> { 1, 1, 2 };
             var individuo = new IndividuoStub(cromosoma, problema);
 
-            decimal fitness = _calculador.CalcularFitness(individuo, problema);
+            decimal fitness = _calculadora.CalcularFitness(individuo, problema);
             Assert.Equal(0, fitness);
         }
 
         private class IndividuoStub : Individuo
         {
-            internal IndividuoStub(List<int> cromosoma, InstanciaProblema problema) : base(cromosoma, problema)
+            internal IndividuoStub(List<int> cromosoma, InstanciaProblema problema)
+                : base(cromosoma, problema, new CalculadoraFitness())
             {
             }
 
@@ -69,10 +69,6 @@ namespace Solver.Tests.Fitness
                 throw new NotImplementedException();
             }
 
-            internal override void CalcularFitness(ICalculadoraFitness calculadoraFitness)
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }

--- a/tests/Solver.Tests/Individuos/IndividuoTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoTests.cs
@@ -1,4 +1,3 @@
-﻿using Solver.Fitness;
 using Solver.Individuos;
 
 namespace Solver.Tests.Individuos
@@ -287,7 +286,8 @@ namespace Solver.Tests.Individuos
 
         private class IndividuoStub : Individuo
         {
-            internal IndividuoStub(List<int> cromosoma, InstanciaProblema problema) : base(cromosoma, problema)
+            internal IndividuoStub(List<int> cromosoma, InstanciaProblema problema)
+                : base(cromosoma, problema, new CalculadoraFitness())
             {
             }
 
@@ -301,10 +301,6 @@ namespace Solver.Tests.Individuos
                 throw new NotImplementedException();
             }
 
-            internal override void CalcularFitness(ICalculadoraFitness calculadoraFitness)
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }

--- a/tests/Solver.Tests/PoblacionTests.cs
+++ b/tests/Solver.Tests/PoblacionTests.cs
@@ -116,8 +116,8 @@ namespace Solver.Tests
                 { 0m, 1m },
             });
 
-            var individuo = Substitute.For<Individuo>(cromosoma, instanciaProblema);
-            individuo.Cruzar(Arg.Any<Individuo>()).Returns(Substitute.For<Individuo>(cromosoma, instanciaProblema));
+            var individuo = Substitute.For<Individuo>(cromosoma, instanciaProblema, new CalculadoraFitness());
+            individuo.Cruzar(Arg.Any<Individuo>()).Returns(Substitute.For<Individuo>(cromosoma, instanciaProblema, new CalculadoraFitness()));
             individuo.Fitness.Returns(fitness);
             return individuo;
         }


### PR DESCRIPTION
En este PR se removió la interface `ICalculadoraFitness`, se renombró `CalculadorEnvyFreeness` a `CalculadoraFitness` y se modificó `Individuo` para que no tenga el método abstracto `CalcularFitness` y reciba por parámetro la calculadora.