### PR TITLE
feat(app): mejoras en la representación del resultado al resolver instancias

### DIFF
--- a/src/App/ResolverCommand.cs
+++ b/src/App/ResolverCommand.cs
@@ -40,7 +40,7 @@ namespace App
             var algoritmoGenetico = new AlgoritmoGenetico(poblacion, parametros.MaxGeneraciones);
 
             (Individuo mejorIndividuo, int generaciones) = algoritmoGenetico.Ejecutar();
-            Console.WriteLine($"Mejor individuo encontrado en {generaciones} generaciones: {mejorIndividuo}");
+            Console.WriteLine($"Mejor individuo encontrado después de {generaciones} generaciones:\n{mejorIndividuo}.");
         }
     }
 }

--- a/src/App/ResolverCommand.cs
+++ b/src/App/ResolverCommand.cs
@@ -39,8 +39,8 @@ namespace App
             var poblacion = PoblacionFactory.Crear(parametros.TamañoPoblacion, individuoFactory);
             var algoritmoGenetico = new AlgoritmoGenetico(poblacion, parametros.MaxGeneraciones);
 
-            Individuo resultado = algoritmoGenetico.Ejecutar();
-            Console.WriteLine($"Mejor individuo encontrado: {resultado}");
+            (Individuo mejorIndividuo, int generaciones) = algoritmoGenetico.Ejecutar();
+            Console.WriteLine($"Mejor individuo encontrado en {generaciones} generaciones: {mejorIndividuo}");
         }
     }
 }

--- a/src/App/ResolverCommand.cs
+++ b/src/App/ResolverCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine;
+using System.Diagnostics;
 using Common;
 using Solver;
 using Solver.Individuos;
@@ -39,8 +40,13 @@ namespace App
             var poblacion = PoblacionFactory.Crear(parametros.TamañoPoblacion, individuoFactory);
             var algoritmoGenetico = new AlgoritmoGenetico(poblacion, parametros.MaxGeneraciones);
 
+            var stopwatch = Stopwatch.StartNew();
             (Individuo mejorIndividuo, int generaciones) = algoritmoGenetico.Ejecutar();
-            Console.WriteLine($"Mejor individuo encontrado después de {generaciones} generaciones:\n{mejorIndividuo}.");
+            stopwatch.Stop();
+
+            Console.WriteLine($"Resultado encontrado después de {generaciones} generaciones.");
+            Console.WriteLine($"{mejorIndividuo}.");
+            Console.WriteLine($"Tiempo de ejecución: {stopwatch.ElapsedMilliseconds} ms.");
         }
     }
 }

--- a/src/Solver/AlgoritmoGenetico.cs
+++ b/src/Solver/AlgoritmoGenetico.cs
@@ -21,7 +21,7 @@ namespace Solver
             _maxGeneraciones = maxGeneraciones;
         }
 
-        public Individuo Ejecutar()
+        public (Individuo mejorIndividuo, int generaciones) Ejecutar()
         {
             int generacion = 0;
             bool ejecutarHastaEncontrarSolucion = _maxGeneraciones == 0;
@@ -33,7 +33,7 @@ namespace Solver
                 {
                     bool esSolucionOptima = individuo.Fitness() == 0;
                     if (esSolucionOptima)
-                        return individuo;
+                        return (individuo, generacion);
                 }
 
                 _poblacion = _poblacion.GenerarNuevaGeneracion();
@@ -41,7 +41,7 @@ namespace Solver
             }
 
             Individuo mejorIndividuo = _poblacion.ObtenerMejorIndividuo();
-            return mejorIndividuo;
+            return (mejorIndividuo, generacion);
         }
     }
 }

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -27,9 +27,9 @@ namespace Solver.Tests
             Poblacion poblacion = CrearPoblacionFakeConIndividuo(individuoOptimo);
 
             var algoritmo = new AlgoritmoGenetico(poblacion, 10);
-            Individuo resultado = algoritmo.Ejecutar();
+            (Individuo mejorIndividuo, int generaciones) = algoritmo.Ejecutar();
 
-            Assert.Same(individuoOptimo, resultado);
+            Assert.Same(individuoOptimo, mejorIndividuo);
         }
 
         [Fact]
@@ -65,10 +65,10 @@ namespace Solver.Tests
             poblacion.ObtenerMejorIndividuo().Returns(mejorIndividuo);
 
             var algoritmo = new AlgoritmoGenetico(poblacion, 1);
-            Individuo resultado = algoritmo.Ejecutar();
+            (Individuo mejorIndividuoEncontrado, int generaciones) = algoritmo.Ejecutar();
 
             poblacion.Received(1).ObtenerMejorIndividuo();
-            Assert.Same(mejorIndividuo, resultado);
+            Assert.Same(mejorIndividuo, mejorIndividuoEncontrado);
         }
 
         [Fact]
@@ -95,9 +95,9 @@ namespace Solver.Tests
             poblacionInicial.GenerarNuevaGeneracion().Returns(poblacionSiguiente);
 
             var algoritmo = new AlgoritmoGenetico(poblacionInicial, 0);
-            Individuo resultado = algoritmo.Ejecutar();
+            (Individuo mejorIndividuo, int generaciones) = algoritmo.Ejecutar();
 
-            Assert.Same(individuoOptimo, resultado);
+            Assert.Same(individuoOptimo, mejorIndividuo);
             poblacionInicial.Received(1).GenerarNuevaGeneracion();
             poblacionSiguiente.DidNotReceive().GenerarNuevaGeneracion();
         }

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -72,7 +72,7 @@ namespace Solver.Tests
         }
 
         [Fact]
-        public void Ejecutar_GeneraNuevasGeneraciones_Correctamente()
+        public void Ejecutar_CantidadGeneracionesGeneradas_EsMaxGeneraciones()
         {
             Poblacion poblacionInicial = CrearPoblacionFakeConIndividuo(CrearIndividuoNoOptimoFake());
             Poblacion poblacionSiguiente = CrearPoblacionFakeConIndividuo(CrearIndividuoNoOptimoFake());

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -27,7 +27,7 @@ namespace Solver.Tests
             Poblacion poblacion = CrearPoblacionFakeConIndividuo(individuoOptimo);
 
             var algoritmo = new AlgoritmoGenetico(poblacion, 10);
-            (Individuo mejorIndividuo, int generaciones) = algoritmo.Ejecutar();
+            (Individuo mejorIndividuo, int _) = algoritmo.Ejecutar();
 
             Assert.Same(individuoOptimo, mejorIndividuo);
         }
@@ -65,7 +65,7 @@ namespace Solver.Tests
             poblacion.ObtenerMejorIndividuo().Returns(mejorIndividuo);
 
             var algoritmo = new AlgoritmoGenetico(poblacion, 1);
-            (Individuo mejorIndividuoEncontrado, int generaciones) = algoritmo.Ejecutar();
+            (Individuo mejorIndividuoEncontrado, int _) = algoritmo.Ejecutar();
 
             poblacion.Received(1).ObtenerMejorIndividuo();
             Assert.Same(mejorIndividuo, mejorIndividuoEncontrado);
@@ -95,7 +95,7 @@ namespace Solver.Tests
             poblacionInicial.GenerarNuevaGeneracion().Returns(poblacionSiguiente);
 
             var algoritmo = new AlgoritmoGenetico(poblacionInicial, 0);
-            (Individuo mejorIndividuo, int generaciones) = algoritmo.Ejecutar();
+            (Individuo mejorIndividuo, int _) = algoritmo.Ejecutar();
 
             Assert.Same(individuoOptimo, mejorIndividuo);
             poblacionInicial.Received(1).GenerarNuevaGeneracion();
@@ -121,6 +121,20 @@ namespace Solver.Tests
 
             individuo1.Received(2).Fitness();
             individuo2.Received(2).Fitness();
+        }
+
+        [Fact]
+        public void Ejecutar_GeneracionesDevueltas_CoincideConGeneracionesGeneradas()
+        {
+            Individuo mejorIndividuo = CrearIndividuoNoOptimoFake();
+            Poblacion poblacion = CrearPoblacionFakeConIndividuo(mejorIndividuo);
+            poblacion.GenerarNuevaGeneracion().Returns(poblacion);
+            poblacion.ObtenerMejorIndividuo().Returns(mejorIndividuo);
+
+            var algoritmo = new AlgoritmoGenetico(poblacion, 1);
+            (Individuo _, int generaciones) = algoritmo.Ejecutar();
+
+            Assert.Equal(1, generaciones);
         }
 
         private Individuo CrearIndividuoOptimoFake()


### PR DESCRIPTION
En este PR se hizo que la salida del comando `resolver` incluya la cantidad de generaciones y el tiempo en milisegundos que llevó encontrar el resultado. Para ello se modificó el tipo de retorno del método `Ejecutar` de `AlgoritmoGenetico`, de `Individuo` a `(Individuo mejorIndividuo, int generaciones)`.