### PR TITLE
feat(resolver-command)!: cambio de nombre de parámetros `--tamaño-poblacion` y `--max-generaciones`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ cc-cli.exe resolver [opciones]
 
 **Opciones secundarias**:
 
-| Opción               | Descripción                            | Valores aceptados              |
-| -------------------- | -------------------------------------- | ------------------------------ |
-| `--max-generaciones` | Generaciones a computar (0 = infinito) | Entero positivo (default: 0)   |
-| `--tamaño-poblacion` | Tamaño de población a utilizar         | Entero positivo (default: 100) |
+| Opción                  | Descripción                            | Valores aceptados              |
+| ----------------------- | -------------------------------------- | ------------------------------ |
+| `--limite-generaciones` | Generaciones a computar (0 = infinito) | Entero positivo (default: 0)   |
+| `--cantidad-individuos` | Cantidad de individuos por generación  | Entero positivo (default: 100) |
 
 **Ejemplos**:
 
@@ -113,13 +113,13 @@ cc-cli.exe resolver [opciones]
 cc-cli.exe resolver --instancia instancia.dat
 
 # Especificando máximo de generaciones
-cc-cli.exe resolver --instancia instancia.dat --max-generaciones 1000
+cc-cli.exe resolver --instancia instancia.dat --limite-generaciones 1000
 
 # Especificando tamaño de población
-cc-cli.exe resolver --instancia instancia.dat --tamaño-poblacion 5000
+cc-cli.exe resolver --instancia instancia.dat --cantidad-individuos 5000
 
 # Ejemplo completo
-cc-cli.exe resolver --instancia instancia.dat --max-generaciones 1000 --tamaño-poblacion 5000
+cc-cli.exe resolver --instancia instancia.dat --limite-generaciones 1000 --cantidad-individuos 5000
 ```
 
 #### 3. Otros comandos

--- a/src/App/ParametrosSolucion.cs
+++ b/src/App/ParametrosSolucion.cs
@@ -2,15 +2,15 @@
 {
     internal class ParametrosSolucion
     {
-        internal ParametrosSolucion(string rutaInstancia, int maxGeneraciones, int tamañoPoblacion)
+        internal ParametrosSolucion(string rutaInstancia, int limiteGeneraciones, int cantidadIndividuos)
         {
             RutaInstancia = rutaInstancia;
-            MaxGeneraciones = maxGeneraciones;
-            TamañoPoblacion = tamañoPoblacion;
+            LimiteGeneraciones = limiteGeneraciones;
+            CantidadIndividuos = cantidadIndividuos;
         }
 
         internal string RutaInstancia { get; }
-        internal int MaxGeneraciones { get; }
-        internal int TamañoPoblacion { get; }
+        internal int LimiteGeneraciones { get; }
+        internal int CantidadIndividuos { get; }
     }
 }

--- a/src/App/ResolverCommand.cs
+++ b/src/App/ResolverCommand.cs
@@ -12,22 +12,22 @@ namespace App
         {
             var command = new Command("resolver", "Resuelve una instancia");
             var instanciaOption = new Option<string>("--instancia") { IsRequired = true };
-            var maxGeneracionesOption = new Option<int>("--max-generaciones", () => 0);
-            var tamañoPoblacionOption = new Option<int>("--tamaño-poblacion", () => 100);
+            var limiteGeneracionesOption = new Option<int>("--limite-generaciones", () => 0);
+            var cantidadIndividuosOption = new Option<int>("--cantidad-individuos", () => 100);
 
             command.AddOption(instanciaOption);
-            command.AddOption(maxGeneracionesOption);
-            command.AddOption(tamañoPoblacionOption);
+            command.AddOption(limiteGeneracionesOption);
+            command.AddOption(cantidadIndividuosOption);
 
-            command.SetHandler((rutaInstancia, maxGeneraciones, tamañoPoblacion) =>
+            command.SetHandler((rutaInstancia, limiteGeneraciones, cantidadIndividuos) =>
             {
-                var parametros = new ParametrosSolucion(rutaInstancia, maxGeneraciones, tamañoPoblacion);
+                var parametros = new ParametrosSolucion(rutaInstancia, limiteGeneraciones, cantidadIndividuos);
 
                 var fileSystemHelper = FileSystemHelperFactory.Crear();
                 var lector = new LectorArchivoMatrizValoraciones(fileSystemHelper);
 
                 Handler(parametros, lector);
-            }, instanciaOption, maxGeneracionesOption, tamañoPoblacionOption);
+            }, instanciaOption, limiteGeneracionesOption, cantidadIndividuosOption);
 
             return command;
         }
@@ -37,8 +37,8 @@ namespace App
             decimal[,] matrizValoraciones = lector.Leer(parametros.RutaInstancia);
             var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matrizValoraciones);
             var individuoFactory = new IndividuoIntercambioAsignacionesFactory(instanciaProblema);
-            var poblacion = PoblacionFactory.Crear(parametros.TamañoPoblacion, individuoFactory);
-            var algoritmoGenetico = new AlgoritmoGenetico(poblacion, parametros.MaxGeneraciones);
+            var poblacion = PoblacionFactory.Crear(parametros.CantidadIndividuos, individuoFactory);
+            var algoritmoGenetico = new AlgoritmoGenetico(poblacion, parametros.LimiteGeneraciones);
 
             var stopwatch = Stopwatch.StartNew();
             (Individuo mejorIndividuo, int generaciones) = algoritmoGenetico.Ejecutar();

--- a/src/Solver/AlgoritmoGenetico.cs
+++ b/src/Solver/AlgoritmoGenetico.cs
@@ -5,27 +5,27 @@ namespace Solver
     public class AlgoritmoGenetico
     {
         private Poblacion _poblacion;
-        private readonly int _maxGeneraciones;
+        private readonly int _limiteGeneraciones;
 
-        public AlgoritmoGenetico(Poblacion poblacion, int maxGeneraciones)
+        public AlgoritmoGenetico(Poblacion poblacion, int limiteGeneraciones)
         {
             ArgumentNullException.ThrowIfNull(poblacion, nameof(poblacion));
 
-            if (maxGeneraciones < 0)
+            if (limiteGeneraciones < 0)
             {
-                string mensaje = "El número máximo de generaciones no puede ser negativo.";
-                throw new ArgumentOutOfRangeException(nameof(maxGeneraciones), mensaje);
+                string mensaje = "El límite de generaciones no puede ser negativo.";
+                throw new ArgumentOutOfRangeException(nameof(limiteGeneraciones), mensaje);
             }
 
             _poblacion = poblacion;
-            _maxGeneraciones = maxGeneraciones;
+            _limiteGeneraciones = limiteGeneraciones;
         }
 
         public (Individuo mejorIndividuo, int generaciones) Ejecutar()
         {
             int generacion = 0;
-            bool ejecutarHastaEncontrarSolucion = _maxGeneraciones == 0;
-            bool generacionLimiteNoAlcanzada = generacion < _maxGeneraciones;
+            bool ejecutarHastaEncontrarSolucion = _limiteGeneraciones == 0;
+            bool generacionLimiteNoAlcanzada = generacion < _limiteGeneraciones;
 
             while (ejecutarHastaEncontrarSolucion || generacionLimiteNoAlcanzada)
             {
@@ -37,7 +37,7 @@ namespace Solver
                 }
 
                 _poblacion = _poblacion.GenerarNuevaGeneracion();
-                generacionLimiteNoAlcanzada = ++generacion < _maxGeneraciones;
+                generacionLimiteNoAlcanzada = ++generacion < _limiteGeneraciones;
             }
 
             Individuo mejorIndividuo = _poblacion.ObtenerMejorIndividuo();

--- a/tests/App.Tests/ResolverCommandTests.cs
+++ b/tests/App.Tests/ResolverCommandTests.cs
@@ -19,26 +19,26 @@ namespace App.Tests
         {
             Assert.Equal("resolver", _command.Name);
             Assert.Contains(_command.Options, o => o.Name == "instancia");
-            Assert.Contains(_command.Options, o => o.Name == "max-generaciones");
-            Assert.Contains(_command.Options, o => o.Name == "tamaño-poblacion");
+            Assert.Contains(_command.Options, o => o.Name == "limite-generaciones");
+            Assert.Contains(_command.Options, o => o.Name == "cantidad-individuos");
         }
 
         [Fact]
-        public void Create_MaxGeneracionesNoEspecificado_UsaValorPorDefecto()
+        public void Create_LimiteGeneracionesNoEspecificado_UsaValorPorDefecto()
         {
-            var maxGeneracionesOption = (Option<int>)_command.Options.First(o => o.Name == "max-generaciones");
-            int maxGeneraciones = _command.Parse("resolver --instancia instancia.dat").GetValueForOption(maxGeneracionesOption);
+            var limiteGeneracionesOption = (Option<int>)_command.Options.First(o => o.Name == "limite-generaciones");
+            int limiteGeneraciones = _command.Parse("resolver --instancia instancia.dat").GetValueForOption(limiteGeneracionesOption);
 
-            Assert.Equal(0, maxGeneraciones);
+            Assert.Equal(0, limiteGeneraciones);
         }
 
         [Fact]
-        public void Create_TamañoPoblacionNoEspecificado_UsaValorPorDefecto()
+        public void Create_CantidadIndividuosNoEspecificado_UsaValorPorDefecto()
         {
-            var tamañoPoblacionOption = (Option<int>)_command.Options.First(o => o.Name == "tamaño-poblacion");
-            int tamañoPoblacion = _command.Parse("resolver --instancia instancia.dat").GetValueForOption(tamañoPoblacionOption);
+            var cantidadIndividuosOption = (Option<int>)_command.Options.First(o => o.Name == "cantidad-individuos");
+            int cantidadIndividuos = _command.Parse("resolver --instancia instancia.dat").GetValueForOption(cantidadIndividuosOption);
 
-            Assert.Equal(100, tamañoPoblacion);
+            Assert.Equal(100, cantidadIndividuos);
         }
 
         [Fact]

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -13,11 +13,11 @@ namespace Solver.Tests
         }
 
         [Fact]
-        public void Constructor_MaxGeneracionesNegativo_LanzaArgumentOutOfRangeException()
+        public void Constructor_LimiteGeneracionesNegativo_LanzaArgumentOutOfRangeException()
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new AlgoritmoGenetico(new Poblacion(1), -1));
             Assert.Contains("no puede ser negativo", ex.Message);
-            Assert.Equal("maxGeneraciones", ex.ParamName);
+            Assert.Equal("limiteGeneraciones", ex.ParamName);
         }
 
         [Fact]
@@ -72,14 +72,14 @@ namespace Solver.Tests
         }
 
         [Fact]
-        public void Ejecutar_CantidadGeneracionesGeneradas_EsMaxGeneraciones()
+        public void Ejecutar_ConLimiteDeGeneraciones_GeneraCantidadEsperadaDeGeneraciones()
         {
             Poblacion poblacionInicial = CrearPoblacionFakeConIndividuo(CrearIndividuoNoOptimoFake());
             Poblacion poblacionSiguiente = CrearPoblacionFakeConIndividuo(CrearIndividuoNoOptimoFake());
             poblacionInicial.GenerarNuevaGeneracion().Returns(poblacionSiguiente);
             poblacionSiguiente.GenerarNuevaGeneracion().Returns(poblacionSiguiente);
 
-            var algoritmo = new AlgoritmoGenetico(poblacionInicial, 2);
+            var algoritmo = new AlgoritmoGenetico(poblacionInicial, limiteGeneraciones: 2);
             algoritmo.Ejecutar();
 
             poblacionInicial.Received(1).GenerarNuevaGeneracion();
@@ -87,14 +87,14 @@ namespace Solver.Tests
         }
 
         [Fact]
-        public void Ejecutar_MaxGeneracionesCero_EjecutaHastaEncontrarSolucion()
+        public void Ejecutar_SinLimiteDeGeneraciones_EjecutaHastaEncontrarSolucionOptima()
         {
             Individuo individuoOptimo = CrearIndividuoOptimoFake();
             Poblacion poblacionInicial = CrearPoblacionFakeConIndividuo(CrearIndividuoNoOptimoFake());
             Poblacion poblacionSiguiente = CrearPoblacionFakeConIndividuo(individuoOptimo);
             poblacionInicial.GenerarNuevaGeneracion().Returns(poblacionSiguiente);
 
-            var algoritmo = new AlgoritmoGenetico(poblacionInicial, 0);
+            var algoritmo = new AlgoritmoGenetico(poblacionInicial, limiteGeneraciones: 0);
             (Individuo mejorIndividuo, int _) = algoritmo.Ejecutar();
 
             Assert.Same(individuoOptimo, mejorIndividuo);


### PR DESCRIPTION
En este PR se cambiaron los nombre de las opciones `--max-generaciones` y `--tamaño-poblacion` por `--limite-generaciones` y `--cantidad-individuos` respectivamente. Límite de generaciones es más descriptivo que el nombre anterior y tamaño de poblaciones podría generar problemas con la ñ, por eso se cambiaron.
Se actualizó el README.md para reflejar los cambios.