### PR TITLE
feat(resolver-command): incorporación de soporte de cancelación para obtención de resultado parcial

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Genera matrices de valoración para el problema. Las instancias generadas usan e
 ...
 ```
 
+El archivo de salida se sobrescribe sin confirmación.
+
 **Sintaxis**:
 
 ```bash
@@ -80,12 +82,12 @@ cc-cli.exe generar --atomos 8 --agentes 2 --output datos/instancia1.txt
 cc-cli.exe generar --atomos 5 --agentes 3 --disjuntas --valor-maximo 500 --output instancia.txt
 ```
 
-- El archivo de salida se sobrescribe sin confirmación.
-
 #### 2. Resolver instancias
 
 Resuelve una instancia del problema de cake-cutting utilizando un algoritmo genético para encontrar una asignación
 libre de envidia.
+Durante la ejecución se puede presionar `Ctrl+C` para finalizar el algoritmo.
+En ese caso se muestra el mejor individuo encontrado hasta el momento.
 
 **Sintaxis**:
 

--- a/src/App/ResolverCommand.cs
+++ b/src/App/ResolverCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.CommandLine;
+using System.CommandLine;
 using System.Diagnostics;
 using Common;
 using Solver;
@@ -40,8 +40,16 @@ namespace App
             var poblacion = PoblacionFactory.Crear(parametros.CantidadIndividuos, individuoFactory);
             var algoritmoGenetico = new AlgoritmoGenetico(poblacion, parametros.LimiteGeneraciones);
 
+            using var cts = new CancellationTokenSource();
+            Console.CancelKeyPress += (_, e) =>
+            {
+                Console.WriteLine("Cancelación solicitada por el usuario");
+                e.Cancel = true;
+                cts.Cancel();
+            };
+
             var stopwatch = Stopwatch.StartNew();
-            (Individuo mejorIndividuo, int generaciones) = algoritmoGenetico.Ejecutar();
+            (Individuo mejorIndividuo, int generaciones) = algoritmoGenetico.Ejecutar(cts.Token);
             stopwatch.Stop();
 
             Console.WriteLine($"Resultado encontrado después de {generaciones} generaciones.");

--- a/src/Solver/AlgoritmoGenetico.cs
+++ b/src/Solver/AlgoritmoGenetico.cs
@@ -1,4 +1,5 @@
-﻿using Solver.Individuos;
+using Solver.Individuos;
+using System.Threading;
 
 namespace Solver
 {
@@ -21,7 +22,7 @@ namespace Solver
             _limiteGeneraciones = limiteGeneraciones;
         }
 
-        public (Individuo mejorIndividuo, int generaciones) Ejecutar()
+        public (Individuo mejorIndividuo, int generaciones) Ejecutar(CancellationToken cancellationToken = default)
         {
             int generacion = 0;
             bool ejecutarHastaEncontrarSolucion = _limiteGeneraciones == 0;
@@ -29,6 +30,9 @@ namespace Solver
 
             while (ejecutarHastaEncontrarSolucion || generacionLimiteNoAlcanzada)
             {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
                 foreach (Individuo individuo in _poblacion.Individuos)
                 {
                     bool esSolucionOptima = individuo.Fitness() == 0;

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -1,5 +1,6 @@
-﻿using NSubstitute;
+using NSubstitute;
 using Solver.Individuos;
+using System.Threading;
 
 namespace Solver.Tests
 {
@@ -135,6 +136,23 @@ namespace Solver.Tests
             (Individuo _, int generaciones) = algoritmo.Ejecutar();
 
             Assert.Equal(1, generaciones);
+        }
+
+        [Fact]
+        public void Ejecutar_EjecucionCancelada_RetornaMejorIndividuoActual()
+        {
+            Individuo mejorIndividuo = CrearIndividuoNoOptimoFake();
+            Poblacion poblacion = CrearPoblacionFakeConIndividuo(mejorIndividuo);
+            poblacion.ObtenerMejorIndividuo().Returns(mejorIndividuo);
+
+            var algoritmo = new AlgoritmoGenetico(poblacion, 10);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            (Individuo individuo, int generaciones) = algoritmo.Ejecutar(cts.Token);
+
+            Assert.Same(mejorIndividuo, individuo);
+            Assert.Equal(0, generaciones);
         }
 
         private Individuo CrearIndividuoOptimoFake()


### PR DESCRIPTION
Este PR agrega soporte para `CancellationToken` al algoritmo genético para permitir cortar la ejecución de la resolución de una instancia y obtener el resultado parcial hasta ese momento.