### PR TITLE
fix(app): despliegue de ayuda cuando se invoca la cli sin argumentos

### DIFF
--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -11,6 +11,12 @@ namespace App
             rootCommand.AddCommand(GenerarCommand.Create());
             rootCommand.AddCommand(ResolverCommand.Create());
 
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Use un subcomando (generar/resolver). Ver ayuda con --help.");
+                return await rootCommand.InvokeAsync("--help");
+            }
+
             int exitCode = await rootCommand.InvokeAsync(args);
             return exitCode;
         }

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -6,14 +6,14 @@ namespace App
     {
         static async Task<int> Main(string[] args)
         {
-            var rootCommand = new RootCommand("Herramienta CLI para Generación/Resolución de Instancias de Cake Cutting");
-            rootCommand.SetHandler(() => Console.WriteLine("Use un subcomando (generar/resolver). Ver ayuda con --help."));
+            var rootCommand = new RootCommand("Herramienta CLI para Generación/Resolución de instancias de Cake Cutting");
             rootCommand.AddCommand(GenerarCommand.Create());
             rootCommand.AddCommand(ResolverCommand.Create());
 
             if (args.Length == 0)
             {
                 Console.WriteLine("Use un subcomando (generar/resolver). Ver ayuda con --help.");
+                Console.WriteLine();
                 return await rootCommand.InvokeAsync("--help");
             }
 


### PR DESCRIPTION
En este PR se modificó `Program.cs` para mostrar la ayuda cuando la aplicación se ejecuta sin argumentos. Se mantiene el mensaje original indicando el uso de subcomandos.