### PR TITLE
fix(resolver-command): se evita línea en blanco innecesaria tras cancelación

### DIFF
--- a/src/App/Commands/Resolver/ResolverCommand.cs
+++ b/src/App/Commands/Resolver/ResolverCommand.cs
@@ -82,7 +82,7 @@ namespace App.Commands.Resolver
         {
             Console.CancelKeyPress += (_, e) =>
             {
-                presentador.MostrarAdvertencia("\nCancelación solicitada por el usuario.");
+                presentador.MostrarAdvertencia("Cancelación solicitada por el usuario.");
                 e.Cancel = true;
                 cts.Cancel();
             };
@@ -121,14 +121,14 @@ namespace App.Commands.Resolver
         private static void MostrarResultado(
             Individuo mejorIndividuo, int generaciones, long tiempoMs, Presentador presentador)
         {
-            presentador.MostrarExito($"\nResultado encontrado después de {generaciones} generaciones.");
+            presentador.MostrarExito($"Resultado encontrado después de {generaciones} generaciones.");
             presentador.MostrarExito($"Resultado obtenido: {mejorIndividuo}.");
             presentador.MostrarExito($"Tiempo de ejecución: {tiempoMs} ms.");
         }
 
         private static void MostrarError(string mensaje, Presentador presentador)
         {
-            presentador.MostrarError($"\nSe produjo un error: {mensaje}");
+            presentador.MostrarError($"Se produjo un error: {mensaje}");
         }
     }
 }

--- a/src/App/Commands/Resolver/ResolverCommand.cs
+++ b/src/App/Commands/Resolver/ResolverCommand.cs
@@ -96,7 +96,8 @@ namespace App.Commands.Resolver
                 const int tamañoBarraProgreso = 50;
                 algoritmoGenetico.GeneracionProcesada += (generacion, cancellationToken) =>
                 {
-                    if (cancellationToken.IsCancellationRequested) return;
+                    if (cancellationToken.IsCancellationRequested)
+                        return;
 
                     int progreso = generacion * tamañoBarraProgreso / parametros.LimiteGeneraciones;
                     string barraProgreso = new string('#', progreso).PadRight(tamañoBarraProgreso, '-');
@@ -108,7 +109,8 @@ namespace App.Commands.Resolver
             {
                 algoritmoGenetico.GeneracionProcesada += (generacion, cancellationToken) =>
                 {
-                    if (cancellationToken.IsCancellationRequested) return;
+                    if (cancellationToken.IsCancellationRequested)
+                        return;
 
                     string mensaje = $"Procesando generación #{generacion}.";
                     presentador.MostrarProgreso(mensaje);

--- a/src/App/Presentador.cs
+++ b/src/App/Presentador.cs
@@ -3,6 +3,7 @@
     internal class Presentador
     {
         private readonly ConsoleProxy _consola;
+        private bool _lineaEnCurso = false;
 
         internal Presentador(ConsoleProxy consola)
         {
@@ -12,22 +13,30 @@
 
         internal void MostrarInfo(string mensaje)
         {
+            AgregarSaltoSiNecesario();
             MostrarMensajeConColor(mensaje, ConsoleColor.White);
+            _lineaEnCurso = false;
         }
 
         internal void MostrarExito(string mensaje)
         {
+            AgregarSaltoSiNecesario();
             MostrarMensajeConColor(mensaje, ConsoleColor.Green);
+            _lineaEnCurso = false;
         }
 
         internal void MostrarAdvertencia(string mensaje)
         {
+            AgregarSaltoSiNecesario();
             MostrarMensajeConColor(mensaje, ConsoleColor.Yellow);
+            _lineaEnCurso = false;
         }
 
         internal void MostrarError(string mensaje)
         {
+            AgregarSaltoSiNecesario();
             MostrarMensajeConColor(mensaje, ConsoleColor.Red);
+            _lineaEnCurso = false;
         }
 
         internal void MostrarProgreso(string mensaje)
@@ -35,6 +44,13 @@
             _consola.ForegroundColor(ConsoleColor.White);
             _consola.Write($"\r{mensaje}");
             _consola.ResetColor();
+            _lineaEnCurso = true;
+        }
+
+        private void AgregarSaltoSiNecesario()
+        {
+            if (_lineaEnCurso)
+                _consola.WriteLine(string.Empty);
         }
 
         private void MostrarMensajeConColor(string mensaje, ConsoleColor color)

--- a/tests/App.Tests/PresentadorTests.cs
+++ b/tests/App.Tests/PresentadorTests.cs
@@ -59,6 +59,28 @@ namespace App.Tests
         }
 
         [Fact]
+        public void MostrarInfo_SinLineaEnCurso_NoAgregaSaltosDeLinea()
+        {
+            (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
+
+            presentador.MostrarInfo(MensajeDePrueba);
+
+            consola.DidNotReceive().WriteLine(string.Empty);
+        }
+
+        [Fact]
+        public void MostrarInfo_LineaEnCurso_AgregaSaltoDeLinea()
+        {
+            (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
+
+            presentador.MostrarProgreso(MensajeDePrueba);
+            presentador.MostrarInfo(MensajeDePrueba);
+
+            consola.Received(1).WriteLine(string.Empty);
+            consola.Received(1).WriteLine(MensajeDePrueba);
+        }
+
+        [Fact]
         public void MostrarExito_Color_EsVerde()
         {
             (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
@@ -101,6 +123,28 @@ namespace App.Tests
                 consola.WriteLine(Arg.Any<string>());
                 consola.ResetColor();
             });
+        }
+
+        [Fact]
+        public void MostrarExito_SinLineaEnCurso_NoAgregaSaltosDeLinea()
+        {
+            (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
+
+            presentador.MostrarExito(MensajeDePrueba);
+
+            consola.DidNotReceive().WriteLine(string.Empty);
+        }
+
+        [Fact]
+        public void MostrarExito_LineaEnCurso_AgregaSaltoDeLinea()
+        {
+            (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
+
+            presentador.MostrarProgreso(MensajeDePrueba);
+            presentador.MostrarExito(MensajeDePrueba);
+
+            consola.Received(1).WriteLine(string.Empty);
+            consola.Received(1).WriteLine(MensajeDePrueba);
         }
 
         [Fact]
@@ -149,6 +193,28 @@ namespace App.Tests
         }
 
         [Fact]
+        public void MostrarAdvertencia_SinLineaEnCurso_NoAgregaSaltosDeLinea()
+        {
+            (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
+
+            presentador.MostrarAdvertencia(MensajeDePrueba);
+
+            consola.DidNotReceive().WriteLine(string.Empty);
+        }
+
+        [Fact]
+        public void MostrarAdvertencia_LineaEnCurso_AgregaSaltoDeLinea()
+        {
+            (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
+
+            presentador.MostrarProgreso(MensajeDePrueba);
+            presentador.MostrarAdvertencia(MensajeDePrueba);
+
+            consola.Received(1).WriteLine(string.Empty);
+            consola.Received(1).WriteLine(MensajeDePrueba);
+        }
+
+        [Fact]
         public void MostrarError_Color_EsRojo()
         {
             (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
@@ -194,6 +260,28 @@ namespace App.Tests
         }
 
         [Fact]
+        public void MostrarError_SinLineaEnCurso_NoAgregaSaltosDeLinea()
+        {
+            (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
+
+            presentador.MostrarError(MensajeDePrueba);
+
+            consola.DidNotReceive().WriteLine(string.Empty);
+        }
+
+        [Fact]
+        public void MostrarError_LineaEnCurso_AgregaSaltoDeLinea()
+        {
+            (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
+
+            presentador.MostrarProgreso(MensajeDePrueba);
+            presentador.MostrarError(MensajeDePrueba);
+
+            consola.Received(1).WriteLine(string.Empty);
+            consola.Received(1).WriteLine(MensajeDePrueba);
+        }
+
+        [Fact]
         public void MostrarProgreso_Color_EsBlanco()
         {
             (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
@@ -236,6 +324,17 @@ namespace App.Tests
                 consola.Write(Arg.Any<string>());
                 consola.ResetColor();
             });
+        }
+
+        [Fact]
+        public void MostrarProgreso_LlamadoConsecutivo_NoAgregaSaltoDeLinea()
+        {
+            (Presentador presentador, ConsoleProxy consola) = CrearPresentadorConConsolaFake();
+
+            presentador.MostrarProgreso(MensajeDePrueba);
+            presentador.MostrarProgreso(MensajeDePrueba);
+
+            consola.DidNotReceive().WriteLine(string.Empty);
         }
 
         private (Presentador presentador, ConsoleProxy consola) CrearPresentadorConConsolaFake()


### PR DESCRIPTION
En este PR se refina el comportamiento del `Presentador` para evitar imprimir líneas en blanco innecesarias luego de mostrar progreso o ante cancelaciones.
Ahora el propio `Presentador` gestiona internamente los saltos de línea, evitando que los consumidores tengan que preocuparse por ese detalle, lo que permitió ajustar los mensajes en `ResolverCommand`.