### PR TITLE
refactor(individuos): remoción de parámetro `CalculadoraFitness` en constructores de `Individuo`

### DIFF
--- a/src/Solver/Individuos/Individuo.cs
+++ b/src/Solver/Individuos/Individuo.cs
@@ -6,20 +6,19 @@ namespace Solver.Individuos
     public abstract class Individuo
     {
         protected readonly InstanciaProblema _problema;
-        protected readonly CalculadoraFitness _calculadoraFitness;
         protected readonly GeneradorNumerosRandom _random;
+        protected readonly CalculadoraFitness _calculadoraFitness;
 
-        protected Individuo(List<int> cromosoma, InstanciaProblema problema, CalculadoraFitness calculadoraFitness)
+        protected Individuo(List<int> cromosoma, InstanciaProblema problema)
         {
             ArgumentNullException.ThrowIfNull(cromosoma, nameof(cromosoma));
             ArgumentNullException.ThrowIfNull(problema, nameof(problema));
-            ArgumentNullException.ThrowIfNull(calculadoraFitness, nameof(calculadoraFitness));
             ValidarCromosoma(cromosoma, problema);
 
             Cromosoma = cromosoma;
             _problema = problema;
-            _calculadoraFitness = calculadoraFitness;
             _random = GeneradorNumerosRandomFactory.Crear();
+            _calculadoraFitness = CalculadoraFitnessFactory.Crear();
         }
 
         internal virtual void Mutar()
@@ -121,7 +120,7 @@ namespace Solver.Individuos
                 throw new ArgumentException(mensaje, nameof(cromosoma));
             }
 
-            List<int> repetidas = asignaciones.GroupBy(a => a).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+            List<int> repetidas = [.. asignaciones.GroupBy(a => a).Where(g => g.Count() > 1).Select(g => g.Key)];
             if (repetidas.Count > 0)
             {
                 string mensaje = $"Hay asignaciones repetidas a agentes: ({string.Join(", ", repetidas)})";

--- a/src/Solver/Individuos/IndividuoIntercambioAsignaciones.cs
+++ b/src/Solver/Individuos/IndividuoIntercambioAsignaciones.cs
@@ -2,9 +2,7 @@ namespace Solver.Individuos;
 
 internal class IndividuoIntercambioAsignaciones : Individuo
 {
-    internal IndividuoIntercambioAsignaciones(
-        List<int> cromosoma, InstanciaProblema problema, CalculadoraFitness calculadoraFitness)
-        : base(cromosoma, problema, calculadoraFitness)
+    internal IndividuoIntercambioAsignaciones(List<int> cromosoma, InstanciaProblema problema) : base(cromosoma, problema)
     {
     }
 
@@ -30,7 +28,7 @@ internal class IndividuoIntercambioAsignaciones : Individuo
 
     protected override Individuo CrearNuevoIndividuo(List<int> cromosoma)
     {
-        var individuo = new IndividuoIntercambioAsignaciones(cromosoma, _problema, _calculadoraFitness);
+        var individuo = new IndividuoIntercambioAsignaciones(cromosoma, _problema);
         return individuo;
     }
 }

--- a/src/Solver/Individuos/IndividuoIntercambioAsignacionesFactory.cs
+++ b/src/Solver/Individuos/IndividuoIntercambioAsignacionesFactory.cs
@@ -6,7 +6,6 @@ public class IndividuoIntercambioAsignacionesFactory : IIndividuoFactory
 {
     private readonly InstanciaProblema _problema;
     private readonly GeneradorNumerosRandom _random;
-    private readonly CalculadoraFitness _calculadoraFitness;
 
     public IndividuoIntercambioAsignacionesFactory(InstanciaProblema problema)
     {
@@ -14,7 +13,6 @@ public class IndividuoIntercambioAsignacionesFactory : IIndividuoFactory
 
         _problema = problema;
         _random = GeneradorNumerosRandomFactory.Crear();
-        _calculadoraFitness = CalculadoraFitnessFactory.Crear();
     }
 
     public Individuo CrearAleatorio()
@@ -24,7 +22,7 @@ public class IndividuoIntercambioAsignacionesFactory : IIndividuoFactory
         List<int> asignaciones = GenerarAsignaciones(cantidadAgentes);
 
         var cromosoma = cortes.Concat(asignaciones).ToList<int>();
-        var individuo = new IndividuoIntercambioAsignaciones(cromosoma, _problema, _calculadoraFitness);
+        var individuo = new IndividuoIntercambioAsignaciones(cromosoma, _problema);
         return individuo;
     }
 

--- a/src/Solver/Individuos/IndividuoOptimizacionAsignaciones.cs
+++ b/src/Solver/Individuos/IndividuoOptimizacionAsignaciones.cs
@@ -2,9 +2,7 @@ namespace Solver.Individuos;
 
 internal class IndividuoOptimizacionAsignaciones : Individuo
 {
-    internal IndividuoOptimizacionAsignaciones(
-        List<int> cromosoma, InstanciaProblema problema, CalculadoraFitness calculadoraFitness)
-        : base(cromosoma, problema, calculadoraFitness)
+    internal IndividuoOptimizacionAsignaciones(List<int> cromosoma, InstanciaProblema problema) : base(cromosoma, problema)
     {
     }
 
@@ -24,7 +22,7 @@ internal class IndividuoOptimizacionAsignaciones : Individuo
 
     protected override Individuo CrearNuevoIndividuo(List<int> cromosoma)
     {
-        var individuo = new IndividuoOptimizacionAsignaciones(cromosoma, _problema, _calculadoraFitness);
+        var individuo = new IndividuoOptimizacionAsignaciones(cromosoma, _problema);
         return individuo;
     }
 

--- a/src/Solver/Individuos/IndividuoOptimizacionAsignacionesFactory.cs
+++ b/src/Solver/Individuos/IndividuoOptimizacionAsignacionesFactory.cs
@@ -6,7 +6,6 @@ public class IndividuoOptimizacionAsignacionesFactory : IIndividuoFactory
 {
     private readonly InstanciaProblema _problema;
     private readonly GeneradorNumerosRandom _random;
-    private readonly CalculadoraFitness _calculadoraFitness;
 
     public IndividuoOptimizacionAsignacionesFactory(InstanciaProblema problema)
     {
@@ -14,7 +13,6 @@ public class IndividuoOptimizacionAsignacionesFactory : IIndividuoFactory
 
         _problema = problema;
         _random = GeneradorNumerosRandomFactory.Crear();
-        _calculadoraFitness = CalculadoraFitnessFactory.Crear();
     }
 
     public Individuo CrearAleatorio()
@@ -24,7 +22,7 @@ public class IndividuoOptimizacionAsignacionesFactory : IIndividuoFactory
         List<int> asignaciones = GenerarAsignaciones(cantidadAgentes);
 
         var cromosoma = cortes.Concat(asignaciones).ToList<int>();
-        var individuo = new IndividuoOptimizacionAsignaciones(cromosoma, _problema, _calculadoraFitness);
+        var individuo = new IndividuoOptimizacionAsignaciones(cromosoma, _problema);
         return individuo;
     }
 

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -225,7 +225,7 @@ namespace Solver.Tests
                 { 0m, 1m },
                 { 0m, 1m },
             });
-            var individuo = Substitute.For<Individuo>(new List<int> { 1, 1, 2 }, instanciaProblema, new CalculadoraFitness());
+            var individuo = Substitute.For<Individuo>(new List<int> { 1, 1, 2 }, instanciaProblema);
             return individuo;
         }
     }

--- a/tests/Solver.Tests/Individuos/CalculadoraFitnessTests.cs
+++ b/tests/Solver.Tests/Individuos/CalculadoraFitnessTests.cs
@@ -54,8 +54,7 @@ namespace Solver.Tests.Individuos
 
         private class IndividuoFake : Individuo
         {
-            internal IndividuoFake(List<int> cromosoma, InstanciaProblema problema)
-                : base(cromosoma, problema, new CalculadoraFitness())
+            internal IndividuoFake(List<int> cromosoma, InstanciaProblema problema) : base(cromosoma, problema)
             {
             }
 

--- a/tests/Solver.Tests/Individuos/IndividuoIntercambioAsignacionesTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoIntercambioAsignacionesTests.cs
@@ -22,7 +22,7 @@ public class IndividuoIntercambioAsignacionesTests : IDisposable
 
         var cromosomaOriginal = new List<int> { 0, 1, 2 };
         var problema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,] { { 1m, 0m }, { 0m, 1m } });
-        var individuo = new IndividuoIntercambioAsignaciones([.. cromosomaOriginal], problema, new CalculadoraFitness());
+        var individuo = new IndividuoIntercambioAsignaciones([.. cromosomaOriginal], problema);
 
         individuo.Mutar();
 

--- a/tests/Solver.Tests/Individuos/IndividuoOptimizacionAsignacionesTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoOptimizacionAsignacionesTests.cs
@@ -27,7 +27,7 @@ public class IndividuoOptimizacionAsignacionesTests : IDisposable
             { 10m, 11m, 12m, 100m },
         });
         var cromosoma = new List<int> { 1, 2, 3, 4, 3, 2, 1 };
-        var individuo = new IndividuoOptimizacionAsignaciones([.. cromosoma], problema, new CalculadoraFitness());
+        var individuo = new IndividuoOptimizacionAsignaciones(cromosoma, problema);
 
         individuo.Mutar();
 

--- a/tests/Solver.Tests/Individuos/IndividuoTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoTests.cs
@@ -446,8 +446,7 @@ namespace Solver.Tests.Individuos
 
         private class IndividuoFake : Individuo
         {
-            internal IndividuoFake(List<int> cromosoma, InstanciaProblema problema)
-                : base(cromosoma, problema, new CalculadoraFitness())
+            internal IndividuoFake(List<int> cromosoma, InstanciaProblema problema) : base(cromosoma, problema)
             {
             }
 

--- a/tests/Solver.Tests/PoblacionTests.cs
+++ b/tests/Solver.Tests/PoblacionTests.cs
@@ -116,8 +116,8 @@ namespace Solver.Tests
                 { 0m, 1m },
             });
 
-            var individuo = Substitute.For<Individuo>(cromosoma, instanciaProblema, new CalculadoraFitness());
-            var otroIndividuo = Substitute.For<Individuo>(cromosoma, instanciaProblema, new CalculadoraFitness());
+            var individuo = Substitute.For<Individuo>(cromosoma, instanciaProblema);
+            var otroIndividuo = Substitute.For<Individuo>(cromosoma, instanciaProblema);
             individuo.Cruzar(Arg.Any<Individuo>()).Returns(otroIndividuo);
             individuo.Fitness().Returns(fitness);
             return individuo;


### PR DESCRIPTION
En este PR se eliminó la inyección explícita de `CalculadoraFitness` en los constructores de `Individuo`, delegando su creación a un factory interno. Esto simplifica los factories de individuos y reduce parámetros innecesarios. Se actualizó también la creación de fakes y clases de test.
