### PR TITLE
refactor(commands): se reemplazaron constructores por inicialización con object initializer

### DIFF
--- a/src/App/Commands/Generar/GenerarCommand.cs
+++ b/src/App/Commands/Generar/GenerarCommand.cs
@@ -44,7 +44,14 @@ namespace App.Commands.Generar
 
             command.SetHandler((atomos, agentes, valorMaximo, output, disjuntas) =>
             {
-                var parametros = new ParametrosGeneracion(atomos, agentes, valorMaximo, output, disjuntas);
+                var parametros = new ParametrosGeneracion
+                {
+                    Atomos = atomos,
+                    Agentes = agentes,
+                    ValorMaximo = valorMaximo,
+                    RutaSalida = output,
+                    ValoracionesDisjuntas = disjuntas,
+                };
 
                 var generadorNumerosRandom = GeneradorNumerosRandomFactory.Crear();
                 var builder = new InstanciaBuilder(generadorNumerosRandom);

--- a/src/App/Commands/Generar/ParametrosGeneracion.cs
+++ b/src/App/Commands/Generar/ParametrosGeneracion.cs
@@ -2,19 +2,10 @@
 {
     internal class ParametrosGeneracion
     {
-        internal ParametrosGeneracion(int atomos, int agentes, int valorMaximo, string rutaSalida, bool valoracionesDisjuntas)
-        {
-            Atomos = atomos;
-            Agentes = agentes;
-            ValorMaximo = valorMaximo;
-            RutaSalida = rutaSalida;
-            ValoracionesDisjuntas = valoracionesDisjuntas;
-        }
-
-        internal int Atomos { get; }
-        internal int Agentes { get; }
-        internal int ValorMaximo { get; }
-        internal string RutaSalida { get; }
-        internal bool ValoracionesDisjuntas { get; }
+        internal int Atomos { get; set; }
+        internal int Agentes { get; set; }
+        internal int ValorMaximo { get; set; }
+        internal string RutaSalida { get; set; }
+        internal bool ValoracionesDisjuntas { get; set; }
     }
 }

--- a/src/App/Commands/Resolver/ParametrosSolucion.cs
+++ b/src/App/Commands/Resolver/ParametrosSolucion.cs
@@ -8,6 +8,6 @@ namespace App.Commands.Resolver
         internal int LimiteGeneraciones { get; set; }
         internal int CantidadIndividuos { get; set; }
         internal int LimiteEstancamiento { get; set; }
-        internal TipoIndividuo TipoIndividuo { get; set; }
+        internal TipoIndividuo TipoIndividuos { get; set; }
     }
 }

--- a/src/App/Commands/Resolver/ParametrosSolucion.cs
+++ b/src/App/Commands/Resolver/ParametrosSolucion.cs
@@ -4,19 +4,10 @@ namespace App.Commands.Resolver
 {
     internal class ParametrosSolucion
     {
-        internal ParametrosSolucion(string rutaInstancia, int limiteGeneraciones, int cantidadIndividuos, int limiteEstancamiento, TipoIndividuo tipoIndividuo)
-        {
-            RutaInstancia = rutaInstancia;
-            LimiteGeneraciones = limiteGeneraciones;
-            CantidadIndividuos = cantidadIndividuos;
-            LimiteEstancamiento = limiteEstancamiento;
-            TipoIndividuo = tipoIndividuo;
-        }
-
-        internal string RutaInstancia { get; }
-        internal int LimiteGeneraciones { get; }
-        internal int CantidadIndividuos { get; }
-        internal int LimiteEstancamiento { get; }
-        internal TipoIndividuo TipoIndividuo { get; }
+        internal string RutaInstancia { get; set; }
+        internal int LimiteGeneraciones { get; set; }
+        internal int CantidadIndividuos { get; set; }
+        internal int LimiteEstancamiento { get; set; }
+        internal TipoIndividuo TipoIndividuo { get; set; }
     }
 }

--- a/src/App/Commands/Resolver/ResolverCommand.cs
+++ b/src/App/Commands/Resolver/ResolverCommand.cs
@@ -42,7 +42,14 @@ namespace App.Commands.Resolver
             command.SetHandler((rutaInstancia, limiteGeneraciones, cantidadIndividuos, limiteEstancamiento, tipoIndividuoStr) =>
             {
                 var tipoIndividuo = TipoIndividuoHelper.Parse(tipoIndividuoStr);
-                var parametros = new ParametrosSolucion(rutaInstancia, limiteGeneraciones, cantidadIndividuos, limiteEstancamiento, tipoIndividuo);
+                var parametros = new ParametrosSolucion
+                {
+                    RutaInstancia = rutaInstancia,
+                    LimiteGeneraciones = limiteGeneraciones,
+                    CantidadIndividuos = cantidadIndividuos,
+                    LimiteEstancamiento = limiteEstancamiento,
+                    TipoIndividuo = tipoIndividuo,
+                };
 
                 var fileSystemHelper = FileSystemHelperFactory.Crear();
                 var lector = new LectorArchivoMatrizValoraciones(fileSystemHelper);

--- a/src/App/Commands/Resolver/ResolverCommand.cs
+++ b/src/App/Commands/Resolver/ResolverCommand.cs
@@ -39,16 +39,16 @@ namespace App.Commands.Resolver
             command.AddOption(limiteEstancamientoOption);
             command.AddOption(tipoIndividuoOption);
 
-            command.SetHandler((rutaInstancia, limiteGeneraciones, cantidadIndividuos, limiteEstancamiento, tipoIndividuoStr) =>
+            command.SetHandler((rutaInstancia, limiteGeneraciones, cantidadIndividuos, limiteEstancamiento, tipoIndividuo) =>
             {
-                var tipoIndividuo = TipoIndividuoHelper.Parse(tipoIndividuoStr);
+                var tipoIndividuos = TipoIndividuoHelper.Parse(tipoIndividuo);
                 var parametros = new ParametrosSolucion
                 {
                     RutaInstancia = rutaInstancia,
                     LimiteGeneraciones = limiteGeneraciones,
                     CantidadIndividuos = cantidadIndividuos,
                     LimiteEstancamiento = limiteEstancamiento,
-                    TipoIndividuo = tipoIndividuo,
+                    TipoIndividuos = tipoIndividuos,
                 };
 
                 var fileSystemHelper = FileSystemHelperFactory.Crear();
@@ -78,7 +78,7 @@ namespace App.Commands.Resolver
             {
                 decimal[,] matrizValoraciones = lector.Leer(parametros.RutaInstancia);
                 var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(matrizValoraciones);
-                var poblacion = PoblacionFactory.Crear(parametros.CantidadIndividuos, instanciaProblema, parametros.TipoIndividuo);
+                var poblacion = PoblacionFactory.Crear(parametros.CantidadIndividuos, instanciaProblema, parametros.TipoIndividuos);
 
                 var algoritmoGenetico = new AlgoritmoGenetico(poblacion, parametros.LimiteGeneraciones, parametros.LimiteEstancamiento);
                 ConfigurarProgreso(parametros, algoritmoGenetico, presentador);

--- a/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
+++ b/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
@@ -66,15 +66,16 @@ namespace App.Tests.Commands.Generar
             builder.ConValoracionesDisjuntas(Arg.Any<bool>()).Returns(builder);
             builder.Build().Returns(instanciaMock);
 
+            var parametros = new ParametrosGeneracion
+            {
+                Atomos = 5,
+                Agentes = 3,
+                ValorMaximo = 100,
+                RutaSalida = "instancia.dat",
+                ValoracionesDisjuntas = true,
+            };
             var escritor = Substitute.For<EscritorInstancia>(Substitute.For<FileSystemHelper>());
             var presentador = Substitute.For<Presentador>(Substitute.For<ConsoleProxy>());
-
-            var parametros = new ParametrosGeneracion(
-                atomos: 5,
-                agentes: 3,
-                valorMaximo: 100,
-                rutaSalida: "instancia.dat",
-                valoracionesDisjuntas: true);
 
             GenerarCommand.EjecutarGeneracion(parametros, builder, escritor, presentador);
 

--- a/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
+++ b/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
@@ -75,7 +75,7 @@ namespace App.Tests.Commands.Resolver
                 LimiteGeneraciones = 1,
                 CantidadIndividuos = 2,
                 LimiteEstancamiento = 3,
-                TipoIndividuo = TipoIndividuo.IntercambioAsignaciones,
+                TipoIndividuos = TipoIndividuo.IntercambioAsignaciones,
             };
             ResolverCommand.EjecutarResolucion(parametros, lector, Substitute.For<Presentador>(Substitute.For<ConsoleProxy>()));
 

--- a/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
+++ b/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
@@ -69,7 +69,14 @@ namespace App.Tests.Commands.Resolver
             var lector = Substitute.For<LectorArchivoMatrizValoraciones>(Substitute.For<FileSystemHelper>());
             lector.Leer(Arg.Any<string>()).Returns(new decimal[,] { { 0, 3.9m }, { 1, 1.2m } });
 
-            var parametros = new ParametrosSolucion("instancia.dat", 1, 2, 3, TipoIndividuo.IntercambioAsignaciones);
+            var parametros = new ParametrosSolucion
+            {
+                RutaInstancia = "instancia.dat",
+                LimiteGeneraciones = 1,
+                CantidadIndividuos = 2,
+                LimiteEstancamiento = 3,
+                TipoIndividuo = TipoIndividuo.IntercambioAsignaciones,
+            };
             ResolverCommand.EjecutarResolucion(parametros, lector, Substitute.For<Presentador>(Substitute.For<ConsoleProxy>()));
 
             lector.Received(1).Leer(parametros.RutaInstancia);


### PR DESCRIPTION
En este PR se actualizaron las clases `ParametrosGeneracion` y `ParametrosSolucion` para permitir setters públicos y se modificaron las instancias en los comandos y tests para usar inicialización por propiedades.