### PR TITLE
refactor(tests): remoción de uso de constructor como función de setup

### DIFF
--- a/src/Generator/InstanciaBuilder.cs
+++ b/src/Generator/InstanciaBuilder.cs
@@ -89,9 +89,8 @@ namespace Generator
             }
 
             var instancia = new decimal[_cantidadAtomos, _cantidadAgentes];
-
-            List<int> atomosDisponibles = Enumerable.Range(0, _cantidadAtomos).ToList();
-            List<int> agentesDisponibles = Enumerable.Range(0, _cantidadAgentes).ToList();
+            var atomosDisponibles = Enumerable.Range(0, _cantidadAtomos).ToList<int>();
+            var agentesDisponibles = Enumerable.Range(0, _cantidadAgentes).ToList<int>();
 
             while (agentesDisponibles.Count > 0)
             {

--- a/src/Solver/Individuos/Individuo.cs
+++ b/src/Solver/Individuos/Individuo.cs
@@ -172,7 +172,7 @@ namespace Solver.Individuos
             if (cantidadAsignaciones <= 1)
                 return [.. asignacionesPadre1];
 
-            var asignacionesHijo = Enumerable.Repeat(-1, cantidadAsignaciones).ToList();
+            var asignacionesHijo = Enumerable.Repeat(-1, cantidadAsignaciones).ToList<int>();
             int indiceInicioSegmento = _random.Siguiente(cantidadAsignaciones);
             int indiceFinSegmento = _random.Siguiente(indiceInicioSegmento, cantidadAsignaciones);
 

--- a/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
+++ b/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
@@ -27,6 +27,7 @@ namespace App.Tests.Commands.Generar
         {
             var comandoGenerar = GenerarCommand.Crear();
             var valorMaximoOption = (Option<int>)comandoGenerar.Options.First(o => o.Name == "valor-maximo");
+
             int valorMaximo = comandoGenerar.Parse("generar --atomos 5 --agentes 3").GetValueForOption(valorMaximoOption);
 
             Assert.Equal(GenerarCommand.ValorMaximoPorDefecto, valorMaximo);
@@ -37,6 +38,7 @@ namespace App.Tests.Commands.Generar
         {
             var comandoGenerar = GenerarCommand.Crear();
             var outputOption = (Option<string>)comandoGenerar.Options.First(o => o.Name == "output");
+
             string output = comandoGenerar.Parse("generar --atomos 5 --agentes 3").GetValueForOption(outputOption);
 
             Assert.Equal(GenerarCommand.RutaSalidaPorDefecto, output);
@@ -47,6 +49,7 @@ namespace App.Tests.Commands.Generar
         {
             var comandoGenerar = GenerarCommand.Crear();
             var disjuntasOption = (Option<bool>)comandoGenerar.Options.First(o => o.Name == "disjuntas");
+
             bool disjuntas = comandoGenerar.Parse("generar --atomos 5 --agentes 3").GetValueForOption(disjuntasOption);
 
             Assert.False(disjuntas);

--- a/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
+++ b/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
@@ -9,29 +9,25 @@ namespace App.Tests.Commands.Generar
 {
     public class GenerarCommandTests
     {
-        private readonly Command _command;
-
-        public GenerarCommandTests()
-        {
-            _command = GenerarCommand.Crear();
-        }
-
         [Fact]
         public void Crear_NombreYOpciones_ConfiguradasCorrectamente()
         {
-            Assert.Equal("generar", _command.Name);
-            Assert.Contains(_command.Options, o => o.Name == "atomos");
-            Assert.Contains(_command.Options, o => o.Name == "agentes");
-            Assert.Contains(_command.Options, o => o.Name == "valor-maximo");
-            Assert.Contains(_command.Options, o => o.Name == "output");
-            Assert.Contains(_command.Options, o => o.Name == "disjuntas");
+            var comandoGenerar = GenerarCommand.Crear();
+
+            Assert.Equal("generar", comandoGenerar.Name);
+            Assert.Contains(comandoGenerar.Options, o => o.Name == "atomos");
+            Assert.Contains(comandoGenerar.Options, o => o.Name == "agentes");
+            Assert.Contains(comandoGenerar.Options, o => o.Name == "valor-maximo");
+            Assert.Contains(comandoGenerar.Options, o => o.Name == "output");
+            Assert.Contains(comandoGenerar.Options, o => o.Name == "disjuntas");
         }
 
         [Fact]
         public void Crear_ValorMaximoNoEspecificado_UsaValorPorDefecto()
         {
-            var valorMaximoOption = (Option<int>)_command.Options.First(o => o.Name == "valor-maximo");
-            int valorMaximo = _command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(valorMaximoOption);
+            var comandoGenerar = GenerarCommand.Crear();
+            var valorMaximoOption = (Option<int>)comandoGenerar.Options.First(o => o.Name == "valor-maximo");
+            int valorMaximo = comandoGenerar.Parse("generar --atomos 5 --agentes 3").GetValueForOption(valorMaximoOption);
 
             Assert.Equal(GenerarCommand.ValorMaximoPorDefecto, valorMaximo);
         }
@@ -39,8 +35,9 @@ namespace App.Tests.Commands.Generar
         [Fact]
         public void Crear_OutputNoEspecificada_UsaValorPorDefecto()
         {
-            var outputOption = (Option<string>)_command.Options.First(o => o.Name == "output");
-            string output = _command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(outputOption);
+            var comandoGenerar = GenerarCommand.Crear();
+            var outputOption = (Option<string>)comandoGenerar.Options.First(o => o.Name == "output");
+            string output = comandoGenerar.Parse("generar --atomos 5 --agentes 3").GetValueForOption(outputOption);
 
             Assert.Equal(GenerarCommand.RutaSalidaPorDefecto, output);
         }
@@ -48,8 +45,9 @@ namespace App.Tests.Commands.Generar
         [Fact]
         public void Crear_DisjuntasNoEspecificada_UsaFalse()
         {
-            var disjuntasOption = (Option<bool>)_command.Options.First(o => o.Name == "disjuntas");
-            bool disjuntas = _command.Parse("generar --atomos 5 --agentes 3").GetValueForOption(disjuntasOption);
+            var comandoGenerar = GenerarCommand.Crear();
+            var disjuntasOption = (Option<bool>)comandoGenerar.Options.First(o => o.Name == "disjuntas");
+            bool disjuntas = comandoGenerar.Parse("generar --atomos 5 --agentes 3").GetValueForOption(disjuntasOption);
 
             Assert.False(disjuntas);
         }

--- a/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
+++ b/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
@@ -9,29 +9,25 @@ namespace App.Tests.Commands.Resolver
 {
     public class ResolverCommandTests
     {
-        private readonly Command _command;
-
-        public ResolverCommandTests()
-        {
-            _command = ResolverCommand.Crear();
-        }
-
         [Fact]
         public void Crear_NombreYOpciones_ConfiguradasCorrectamente()
         {
-            Assert.Equal("resolver", _command.Name);
-            Assert.Contains(_command.Options, o => o.Name == "instancia");
-            Assert.Contains(_command.Options, o => o.Name == "limite-generaciones");
-            Assert.Contains(_command.Options, o => o.Name == "cantidad-individuos");
-            Assert.Contains(_command.Options, o => o.Name == "limite-estancamiento");
-            Assert.Contains(_command.Options, o => o.Name == "tipo-individuo");
+            var comandoResolver = ResolverCommand.Crear();
+
+            Assert.Equal("resolver", comandoResolver.Name);
+            Assert.Contains(comandoResolver.Options, o => o.Name == "instancia");
+            Assert.Contains(comandoResolver.Options, o => o.Name == "limite-generaciones");
+            Assert.Contains(comandoResolver.Options, o => o.Name == "cantidad-individuos");
+            Assert.Contains(comandoResolver.Options, o => o.Name == "limite-estancamiento");
+            Assert.Contains(comandoResolver.Options, o => o.Name == "tipo-individuo");
         }
 
         [Fact]
         public void Crear_LimiteGeneracionesNoEspecificado_UsaValorPorDefecto()
         {
-            var limiteGeneracionesOption = (Option<int>)_command.Options.First(o => o.Name == "limite-generaciones");
-            int limiteGeneraciones = _command.Parse("resolver --instancia instancia.dat").GetValueForOption(limiteGeneracionesOption);
+            var comandoResolver = ResolverCommand.Crear();
+            var limiteGeneracionesOption = (Option<int>)comandoResolver.Options.First(o => o.Name == "limite-generaciones");
+            int limiteGeneraciones = comandoResolver.Parse("resolver --instancia instancia.dat").GetValueForOption(limiteGeneracionesOption);
 
             Assert.Equal(0, limiteGeneraciones);
         }
@@ -39,8 +35,9 @@ namespace App.Tests.Commands.Resolver
         [Fact]
         public void Crear_CantidadIndividuosNoEspecificado_UsaValorPorDefecto()
         {
-            var cantidadIndividuosOption = (Option<int>)_command.Options.First(o => o.Name == "cantidad-individuos");
-            int cantidadIndividuos = _command.Parse("resolver --instancia instancia.dat").GetValueForOption(cantidadIndividuosOption);
+            var comandoResolver = ResolverCommand.Crear();
+            var cantidadIndividuosOption = (Option<int>)comandoResolver.Options.First(o => o.Name == "cantidad-individuos");
+            int cantidadIndividuos = comandoResolver.Parse("resolver --instancia instancia.dat").GetValueForOption(cantidadIndividuosOption);
 
             Assert.Equal(100, cantidadIndividuos);
         }
@@ -48,8 +45,9 @@ namespace App.Tests.Commands.Resolver
         [Fact]
         public void Crear_LimiteEstancamientoNoEspecificado_UsaValorPorDefecto()
         {
-            var limiteEstancamientoOption = (Option<int>)_command.Options.First(o => o.Name == "limite-estancamiento");
-            int limiteEstancamiento = _command.Parse("resolver --instancia instancia.dat").GetValueForOption(limiteEstancamientoOption);
+            var comandoResolver = ResolverCommand.Crear();
+            var limiteEstancamientoOption = (Option<int>)comandoResolver.Options.First(o => o.Name == "limite-estancamiento");
+            int limiteEstancamiento = comandoResolver.Parse("resolver --instancia instancia.dat").GetValueForOption(limiteEstancamientoOption);
 
             Assert.Equal(1000, limiteEstancamiento);
         }
@@ -57,8 +55,9 @@ namespace App.Tests.Commands.Resolver
         [Fact]
         public void Crear_TipoIndividuoNoEspecificado_UsaValorPorDefecto()
         {
-            var tipoIndividuoOption = (Option<string>)_command.Options.First(o => o.Name == "tipo-individuo");
-            string tipoIndividuo = _command.Parse("resolver --instancia instancia.dat").GetValueForOption(tipoIndividuoOption);
+            var comandoResolver = ResolverCommand.Crear();
+            var tipoIndividuoOption = (Option<string>)comandoResolver.Options.First(o => o.Name == "tipo-individuo");
+            string tipoIndividuo = comandoResolver.Parse("resolver --instancia instancia.dat").GetValueForOption(tipoIndividuoOption);
 
             Assert.Equal("intercambio", tipoIndividuo);
         }

--- a/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
+++ b/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
@@ -3,7 +3,6 @@ using App.Commands.Resolver;
 using Common;
 using NSubstitute;
 using Solver;
-using Solver.Individuos;
 
 namespace App.Tests.Commands.Resolver
 {
@@ -27,7 +26,10 @@ namespace App.Tests.Commands.Resolver
         {
             var comandoResolver = ResolverCommand.Crear();
             var limiteGeneracionesOption = (Option<int>)comandoResolver.Options.First(o => o.Name == "limite-generaciones");
-            int limiteGeneraciones = comandoResolver.Parse("resolver --instancia instancia.dat").GetValueForOption(limiteGeneracionesOption);
+
+            int limiteGeneraciones = comandoResolver
+                .Parse("resolver --instancia instancia.dat")
+                .GetValueForOption(limiteGeneracionesOption);
 
             Assert.Equal(0, limiteGeneraciones);
         }
@@ -37,7 +39,10 @@ namespace App.Tests.Commands.Resolver
         {
             var comandoResolver = ResolverCommand.Crear();
             var cantidadIndividuosOption = (Option<int>)comandoResolver.Options.First(o => o.Name == "cantidad-individuos");
-            int cantidadIndividuos = comandoResolver.Parse("resolver --instancia instancia.dat").GetValueForOption(cantidadIndividuosOption);
+
+            int cantidadIndividuos = comandoResolver
+                .Parse("resolver --instancia instancia.dat")
+                .GetValueForOption(cantidadIndividuosOption);
 
             Assert.Equal(100, cantidadIndividuos);
         }
@@ -47,7 +52,10 @@ namespace App.Tests.Commands.Resolver
         {
             var comandoResolver = ResolverCommand.Crear();
             var limiteEstancamientoOption = (Option<int>)comandoResolver.Options.First(o => o.Name == "limite-estancamiento");
-            int limiteEstancamiento = comandoResolver.Parse("resolver --instancia instancia.dat").GetValueForOption(limiteEstancamientoOption);
+
+            int limiteEstancamiento = comandoResolver
+                .Parse("resolver --instancia instancia.dat")
+                .GetValueForOption(limiteEstancamientoOption);
 
             Assert.Equal(1000, limiteEstancamiento);
         }
@@ -57,7 +65,10 @@ namespace App.Tests.Commands.Resolver
         {
             var comandoResolver = ResolverCommand.Crear();
             var tipoIndividuoOption = (Option<string>)comandoResolver.Options.First(o => o.Name == "tipo-individuo");
-            string tipoIndividuo = comandoResolver.Parse("resolver --instancia instancia.dat").GetValueForOption(tipoIndividuoOption);
+
+            string tipoIndividuo = comandoResolver
+                .Parse("resolver --instancia instancia.dat")
+                .GetValueForOption(tipoIndividuoOption);
 
             Assert.Equal("intercambio", tipoIndividuo);
         }
@@ -65,20 +76,17 @@ namespace App.Tests.Commands.Resolver
         [Fact]
         public void EjecutarResolucion_MatrizValoraciones_SeLee()
         {
-            var lector = Substitute.For<LectorArchivoMatrizValoraciones>(Substitute.For<FileSystemHelper>());
-            lector.Leer(Arg.Any<string>()).Returns(new decimal[,] { { 0, 3.9m }, { 1, 1.2m } });
-
             var parametros = new ParametrosSolucion
             {
-                RutaInstancia = "instancia.dat",
-                LimiteGeneraciones = 1,
-                CantidadIndividuos = 2,
-                LimiteEstancamiento = 3,
-                TipoIndividuos = TipoIndividuo.IntercambioAsignaciones,
+                RutaInstancia = "ruta/a/instancia.dat",
             };
-            ResolverCommand.EjecutarResolucion(parametros, lector, Substitute.For<Presentador>(Substitute.For<ConsoleProxy>()));
 
-            lector.Received(1).Leer(parametros.RutaInstancia);
+            var lector = Substitute.For<LectorArchivoMatrizValoraciones>(Substitute.For<FileSystemHelper>());
+            var presentador = Substitute.For<Presentador>(Substitute.For<ConsoleProxy>());
+
+            ResolverCommand.EjecutarResolucion(parametros, lector, presentador);
+
+            lector.Received(1).Leer("ruta/a/instancia.dat");
         }
     }
 }

--- a/tests/Generator.Tests/EscritorInstanciaTests.cs
+++ b/tests/Generator.Tests/EscritorInstanciaTests.cs
@@ -65,12 +65,12 @@ namespace Generator.Tests
         public void EscribirInstancia_DirectorioNoExistente_LoCrea()
         {
             var fileSystemHelper = Substitute.For<FileSystemHelper>();
-            fileSystemHelper.DirectoryExists("directorio\\salida").Returns(false);
+            fileSystemHelper.DirectoryExists("directorio").Returns(false);
 
             EscritorInstancia escritorInstancia = ObtenerEscritorInstancia(fileSystemHelper);
-            escritorInstancia.EscribirInstancia(_instancia, RutaArchivo);
+            escritorInstancia.EscribirInstancia(_instancia, "directorio/instancia.dat");
 
-            fileSystemHelper.Received(1).CreateDirectory("directorio\\salida");
+            fileSystemHelper.Received(1).CreateDirectory("directorio");
         }
 
         [Fact]

--- a/tests/Generator.Tests/EscritorInstanciaTests.cs
+++ b/tests/Generator.Tests/EscritorInstanciaTests.cs
@@ -5,9 +5,7 @@ namespace Generator.Tests
 {
     public class EscritorInstanciaTests
     {
-        private const string DirectorioSalida = "nombreCarpeta";
-        private const string ArchivoSalida = "instancia.dat";
-
+        private const string RutaArchivo = "directorio\\salida\\instancia.dat";
         private readonly decimal[,] _instancia = new decimal[,] { { 1 } };
 
         [Fact]
@@ -22,7 +20,7 @@ namespace Generator.Tests
         {
             EscritorInstancia escritorInstancia = ObtenerEscritorInstancia();
 
-            var ex = Assert.Throws<ArgumentNullException>(() => escritorInstancia.EscribirInstancia(null, ArchivoSalida));
+            var ex = Assert.Throws<ArgumentNullException>(() => escritorInstancia.EscribirInstancia(null, RutaArchivo));
             Assert.Equal("instancia", ex.ParamName);
         }
 
@@ -45,7 +43,7 @@ namespace Generator.Tests
             var fileSystemHelper = Substitute.For<FileSystemHelper>();
 
             EscritorInstancia escritorInstancia = ObtenerEscritorInstancia(fileSystemHelper);
-            escritorInstancia.EscribirInstancia(_instancia, ArchivoSalida);
+            escritorInstancia.EscribirInstancia(_instancia, "instancia.dat");
 
             fileSystemHelper.DidNotReceive().DirectoryExists(Arg.Any<string>());
             fileSystemHelper.DidNotReceive().CreateDirectory(Arg.Any<string>());
@@ -55,10 +53,10 @@ namespace Generator.Tests
         public void EscribirInstancia_DirectorioExistente_NoIntentaCrearlo()
         {
             var fileSystemHelper = Substitute.For<FileSystemHelper>();
-            fileSystemHelper.DirectoryExists(DirectorioSalida).Returns(true);
+            fileSystemHelper.DirectoryExists("directorio\\salida").Returns(true);
 
             EscritorInstancia escritorInstancia = ObtenerEscritorInstancia(fileSystemHelper);
-            escritorInstancia.EscribirInstancia(_instancia, DirectorioSalida + "/" + ArchivoSalida);
+            escritorInstancia.EscribirInstancia(_instancia, RutaArchivo);
 
             fileSystemHelper.DidNotReceive().CreateDirectory(Arg.Any<string>());
         }
@@ -67,12 +65,12 @@ namespace Generator.Tests
         public void EscribirInstancia_DirectorioNoExistente_LoCrea()
         {
             var fileSystemHelper = Substitute.For<FileSystemHelper>();
-            fileSystemHelper.DirectoryExists(DirectorioSalida).Returns(false);
+            fileSystemHelper.DirectoryExists("directorio\\salida").Returns(false);
 
             EscritorInstancia escritorInstancia = ObtenerEscritorInstancia(fileSystemHelper);
-            escritorInstancia.EscribirInstancia(_instancia, DirectorioSalida + "/" + ArchivoSalida);
+            escritorInstancia.EscribirInstancia(_instancia, RutaArchivo);
 
-            fileSystemHelper.Received(1).CreateDirectory(DirectorioSalida);
+            fileSystemHelper.Received(1).CreateDirectory("directorio\\salida");
         }
 
         [Fact]
@@ -81,9 +79,9 @@ namespace Generator.Tests
             var fileSystemHelper = Substitute.For<FileSystemHelper>();
 
             EscritorInstancia escritorInstancia = ObtenerEscritorInstancia(fileSystemHelper);
-            escritorInstancia.EscribirInstancia(new decimal[,] { { 1, 2, 3 }, { 4, 5, 6 } }, ArchivoSalida);
+            escritorInstancia.EscribirInstancia(new decimal[,] { { 1, 2, 3 }, { 4, 5, 6 } }, RutaArchivo);
 
-            fileSystemHelper.Received(1).WriteAllLines(ArchivoSalida, Arg.Is<List<string>>(x =>
+            fileSystemHelper.Received(1).WriteAllLines(RutaArchivo, Arg.Is<List<string>>(x =>
                 x.Count == 3 &&
                 x[0] == "2 3" &&
                 x[1] == "1\t2\t3" &&
@@ -97,9 +95,9 @@ namespace Generator.Tests
             var fileSystemHelper = Substitute.For<FileSystemHelper>();
 
             EscritorInstancia escritorInstancia = ObtenerEscritorInstancia(fileSystemHelper);
-            escritorInstancia.EscribirInstancia(new decimal[0, 0], ArchivoSalida);
+            escritorInstancia.EscribirInstancia(new decimal[0, 0], RutaArchivo);
 
-            fileSystemHelper.Received(1).WriteAllLines(ArchivoSalida, Arg.Is<List<string>>(x =>
+            fileSystemHelper.Received(1).WriteAllLines(RutaArchivo, Arg.Is<List<string>>(x =>
                 x.Count == 1 &&
                 x[0] == "0 0"
             ));
@@ -117,7 +115,7 @@ namespace Generator.Tests
 
             EscritorInstancia escritorInstancia = ObtenerEscritorInstancia(fileSystemHelper);
 
-            var ex = Assert.Throws<IOException>(() => escritorInstancia.EscribirInstancia(_instancia, ArchivoSalida));
+            var ex = Assert.Throws<IOException>(() => escritorInstancia.EscribirInstancia(_instancia, RutaArchivo));
             Assert.Contains(mensajeExcepcionInterna, ex.Message);
         }
 

--- a/tests/Generator.Tests/Generator.Tests.csproj
+++ b/tests/Generator.Tests/Generator.Tests.csproj
@@ -7,6 +7,9 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+
+    <!-- Deshabilito CA1822:Mark members as static -->
+    <NoWarn>CA1822</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Generator.Tests/InstanciaBuilderTests.cs
+++ b/tests/Generator.Tests/InstanciaBuilderTests.cs
@@ -5,14 +5,6 @@ namespace Generator.Tests
 {
     public class InstanciaBuilderTests
     {
-        private readonly InstanciaBuilder _instanciaBuilder;
-
-        public InstanciaBuilderTests()
-        {
-            var generadorNumerosRandom = Substitute.For<GeneradorNumerosRandom>();
-            _instanciaBuilder = new InstanciaBuilder(generadorNumerosRandom);
-        }
-
         [Fact]
         public void Constructor_GeneradorNumerosRandomNull_LanzaArgumentNullException()
         {
@@ -25,7 +17,9 @@ namespace Generator.Tests
         [InlineData(-1)]
         public void ConCantidadDeAtomos_CantidadInvalida_LanzaArgumentOutOfRangeException(int cantidadAtomos)
         {
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _instanciaBuilder.ConCantidadDeAtomos(cantidadAtomos));
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder();
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => instanciaBuilder.ConCantidadDeAtomos(cantidadAtomos));
             Assert.Contains("debe ser mayor que cero", ex.Message);
             Assert.Equal("cantidadAtomos", ex.ParamName);
         }
@@ -35,7 +29,9 @@ namespace Generator.Tests
         [InlineData(-1)]
         public void ConCantidadDeAgentes_CantidadInvalida_LanzaArgumentOutOfRangeException(int cantidadAgentes)
         {
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _instanciaBuilder.ConCantidadDeAgentes(cantidadAgentes));
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder();
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => instanciaBuilder.ConCantidadDeAgentes(cantidadAgentes));
             Assert.Contains("debe ser mayor que cero", ex.Message);
             Assert.Equal("cantidadAgentes", ex.ParamName);
         }
@@ -45,7 +41,9 @@ namespace Generator.Tests
         [InlineData(-1)]
         public void ConValorMaximo_CantidadInvalida_LanzaArgumentOutOfRangeException(int valorMaximo)
         {
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _instanciaBuilder.ConValorMaximo(valorMaximo));
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder();
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => instanciaBuilder.ConValorMaximo(valorMaximo));
             Assert.Contains("debe ser positivo", ex.Message);
             Assert.Equal("valorMaximo", ex.ParamName);
         }
@@ -53,65 +51,65 @@ namespace Generator.Tests
         [Fact]
         public void Build_SinAtomosSeteados_LanzaInvalidOperationException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder.Build);
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => instanciaBuilder.Build());
             Assert.Contains("especificar el número de átomos", ex.Message);
         }
 
         [Fact]
         public void Build_SinAgentesSeteados_LanzaInvalidOperationException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
-                .ConCantidadDeAtomos(2)
-                .Build);
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder().ConCantidadDeAtomos(2);
 
+            var ex = Assert.Throws<InvalidOperationException>(instanciaBuilder.Build);
             Assert.Contains("especificar el número de agentes", ex.Message);
         }
 
         [Fact]
         public void Build_SinValorMaximoSeteado_LanzaInvalidOperationException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
-                .ConCantidadDeAtomos(2)
-                .ConCantidadDeAgentes(2)
-                .Build);
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder().ConCantidadDeAtomos(2).ConCantidadDeAgentes(2);
 
+            var ex = Assert.Throws<InvalidOperationException>(instanciaBuilder.Build);
             Assert.Contains("especificar el valor máximo", ex.Message);
         }
 
         [Fact]
         public void Build_SinTipoDeInstanciaSeteado_LanzaInvalidOperationException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder()
                 .ConCantidadDeAtomos(2)
                 .ConCantidadDeAgentes(2)
-                .ConValorMaximo(5)
-                .Build);
+                .ConValorMaximo(5);
 
+            var ex = Assert.Throws<InvalidOperationException>(instanciaBuilder.Build);
             Assert.Contains("especificar el tipo", ex.Message);
         }
 
         [Fact]
         public void Build_ValoracionesDisjuntasConMasAgentesQueAtomos_LanzaInvalidOperationException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(_instanciaBuilder
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder()
                 .ConCantidadDeAtomos(2)
                 .ConCantidadDeAgentes(3)
                 .ConValorMaximo(5)
-                .ConValoracionesDisjuntas(true)
-                .Build);
+                .ConValoracionesDisjuntas(true);
 
+            var ex = Assert.Throws<InvalidOperationException>(instanciaBuilder.Build);
             Assert.Contains("más agentes que átomos", ex.Message);
         }
 
         [Fact]
         public void Build_ConfiguracionCorrecta_DevuelveMatrizCorrecta()
         {
-            decimal[,] instancia = _instanciaBuilder
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder()
                 .ConCantidadDeAtomos(3)
                 .ConCantidadDeAgentes(2)
                 .ConValorMaximo(5)
-                .ConValoracionesDisjuntas(true)
-                .Build();
+                .ConValoracionesDisjuntas(true);
+
+            decimal[,] instancia = instanciaBuilder.Build();
 
             Assert.Equal(3, instancia.GetLength(0));
             Assert.Equal(2, instancia.GetLength(1));
@@ -122,12 +120,13 @@ namespace Generator.Tests
         [InlineData(50)]
         public void Build_ValorMaximoConfigurado_RespetaLimiteSuperior(int valorMaximo)
         {
-            decimal[,] instancia = _instanciaBuilder
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder()
                 .ConCantidadDeAtomos(3)
                 .ConCantidadDeAgentes(3)
                 .ConValorMaximo(valorMaximo)
-                .ConValoracionesDisjuntas(false)
-                .Build();
+                .ConValoracionesDisjuntas(false);
+
+            decimal[,] instancia = instanciaBuilder.Build();
 
             Assert.InRange(instancia[0, 0], 0, valorMaximo);
             Assert.InRange(instancia[0, 1], 0, valorMaximo);
@@ -147,25 +146,23 @@ namespace Generator.Tests
             generadorNumerosRandom.Siguiente(Arg.Any<int>()).Returns(0);
             generadorNumerosRandom.Siguiente(Arg.Any<int>(), Arg.Any<int>()).Returns(1, 2, 3, 4);
 
-            decimal[,] instancia = new InstanciaBuilder(generadorNumerosRandom)
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder(generadorNumerosRandom)
                 .ConCantidadDeAtomos(4)
                 .ConCantidadDeAgentes(3)
                 .ConValorMaximo(5)
-                .ConValoracionesDisjuntas(true)
-                .Build();
+                .ConValoracionesDisjuntas(true);
+
+            decimal[,] instancia = instanciaBuilder.Build();
 
             Assert.Equal(1, instancia[0, 0]);
             Assert.Equal(0, instancia[0, 1]);
             Assert.Equal(0, instancia[0, 2]);
-
             Assert.Equal(0, instancia[1, 0]);
             Assert.Equal(2, instancia[1, 1]);
             Assert.Equal(0, instancia[1, 2]);
-
             Assert.Equal(0, instancia[2, 0]);
             Assert.Equal(0, instancia[2, 1]);
             Assert.Equal(3, instancia[2, 2]);
-
             Assert.Equal(4, instancia[3, 0]);
             Assert.Equal(0, instancia[3, 1]);
             Assert.Equal(0, instancia[3, 2]);
@@ -178,12 +175,13 @@ namespace Generator.Tests
             generadorNumerosRandom.Siguiente(Arg.Any<int>()).Returns(0);
             generadorNumerosRandom.Siguiente(Arg.Any<int>(), Arg.Any<int>()).Returns(1, 2, 3);
 
-            decimal[,] instancia = new InstanciaBuilder(generadorNumerosRandom)
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder(generadorNumerosRandom)
                 .ConCantidadDeAtomos(3)
                 .ConCantidadDeAgentes(1)
                 .ConValorMaximo(5)
-                .ConValoracionesDisjuntas(true)
-                .Build();
+                .ConValoracionesDisjuntas(true);
+
+            decimal[,] instancia = instanciaBuilder.Build();
 
             Assert.Equal(1, instancia[0, 0]);
             Assert.Equal(2, instancia[1, 0]);
@@ -198,12 +196,13 @@ namespace Generator.Tests
             var generadorNumerosRandom = Substitute.For<GeneradorNumerosRandom>();
             generadorNumerosRandom.Siguiente(1, valorMaximo + 1).Returns(1);
 
-            decimal[,] instancia = new InstanciaBuilder(generadorNumerosRandom)
+            InstanciaBuilder instanciaBuilder = ObtenerInstanciaBuilder(generadorNumerosRandom)
                 .ConCantidadDeAtomos(3)
                 .ConCantidadDeAgentes(3)
                 .ConValorMaximo(valorMaximo)
-                .ConValoracionesDisjuntas(false)
-                .Build();
+                .ConValoracionesDisjuntas(false);
+
+            decimal[,] instancia = instanciaBuilder.Build();
 
             generadorNumerosRandom.Received(9).Siguiente(1, valorMaximo + 1);
             Assert.NotEqual(0, instancia[0, 0]);
@@ -215,6 +214,19 @@ namespace Generator.Tests
             Assert.NotEqual(0, instancia[2, 0]);
             Assert.NotEqual(0, instancia[2, 1]);
             Assert.NotEqual(0, instancia[2, 2]);
+        }
+
+        private InstanciaBuilder ObtenerInstanciaBuilder()
+        {
+            var generadorNumerosRandom = Substitute.For<GeneradorNumerosRandom>();
+            var instanciaBuilder = new InstanciaBuilder(generadorNumerosRandom);
+            return instanciaBuilder;
+        }
+
+        private InstanciaBuilder ObtenerInstanciaBuilder(GeneradorNumerosRandom generador)
+        {
+            var instanciaBuilder = new InstanciaBuilder(generador);
+            return instanciaBuilder;
         }
     }
 }

--- a/tests/Solver.Tests/AgenteTests.cs
+++ b/tests/Solver.Tests/AgenteTests.cs
@@ -2,26 +2,19 @@
 {
     public class AgenteTests
     {
-        private const int IdAgente = 1;
-
-        private readonly Agente _agente;
-
-        public AgenteTests()
-        {
-            _agente = new Agente(IdAgente);
-        }
-
         [Fact]
         public void Constructor_Id_SeAsigna()
         {
-            Assert.Equal(IdAgente, _agente.Id);
+            var agente = new Agente(1);
+            Assert.Equal(1, agente.Id);
         }
 
         [Fact]
         public void Constructor_Valoraciones_SeInicializaVacia()
         {
-            Assert.NotNull(_agente.Valoraciones);
-            Assert.Empty(_agente.Valoraciones);
+            var agente = new Agente(1);
+            Assert.NotNull(agente.Valoraciones);
+            Assert.Empty(agente.Valoraciones);
         }
 
         [Fact]
@@ -30,12 +23,13 @@
             var atomo1 = new Atomo(1, 1);
             var atomo2 = new Atomo(2, 1);
 
-            _agente.AgregarValoracion(atomo1);
-            _agente.AgregarValoracion(atomo2);
+            Agente agente = ObtenerAgente();
+            agente.AgregarValoracion(atomo1);
+            agente.AgregarValoracion(atomo2);
 
-            Assert.True(_agente.Valoraciones.Count == 2);
-            Assert.Same(atomo1, _agente.Valoraciones[0]);
-            Assert.Same(atomo2, _agente.Valoraciones[1]);
+            Assert.Equal(2, agente.Valoraciones.Count);
+            Assert.Same(atomo1, agente.Valoraciones[0]);
+            Assert.Same(atomo2, agente.Valoraciones[1]);
         }
 
         [Fact]
@@ -43,10 +37,17 @@
         {
             const int posicion = 1;
 
-            _agente.AgregarValoracion(new Atomo(posicion, 1));
+            Agente agente = ObtenerAgente();
+            agente.AgregarValoracion(new Atomo(posicion, 1));
 
-            var ex = Assert.Throws<InvalidOperationException>(() => _agente.AgregarValoracion(new Atomo(posicion, 0)));
+            var ex = Assert.Throws<InvalidOperationException>(() => agente.AgregarValoracion(new Atomo(posicion, 0)));
             Assert.Contains("Ya existe valoración para el átomo", ex.Message);
+        }
+
+        private Agente ObtenerAgente()
+        {
+            var agente = new Agente(1);
+            return agente;
         }
     }
 }

--- a/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
+++ b/tests/Solver.Tests/LectorArchivoMatrizValoracionesTests.cs
@@ -7,20 +7,8 @@ namespace Solver.Tests
     {
         private const string RutaArchivo = "rutaArchivo.txt";
 
-        private readonly FileSystemHelper _fileSystemHelper;
-        private readonly LectorArchivoMatrizValoraciones _lector;
-
-        public LectorArchivoMatrizValoracionesTests()
-        {
-            _fileSystemHelper = Substitute.For<FileSystemHelper>();
-            _fileSystemHelper.FileExists(Arg.Any<string>()).Returns(true);
-            _fileSystemHelper.ReadAllLines(Arg.Any<string>()).Returns([]);
-
-            _lector = new LectorArchivoMatrizValoraciones(_fileSystemHelper);
-        }
-
         [Fact]
-        public void Constructor_FileSystemHelperNull_LanzaArgumentNullException()
+        public void ConstructorfileSystemHelperNull_LanzaArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => new LectorArchivoMatrizValoraciones(null));
             Assert.Equal("fileSystemHelper", ex.ParamName);
@@ -29,7 +17,10 @@ namespace Solver.Tests
         [Fact]
         public void Leer_RutaNull_LanzaArgumentNullException()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => _lector.Leer(null));
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<ArgumentNullException>(() => lector.Leer(null));
             Assert.Equal("rutaArchivo", ex.ParamName);
         }
 
@@ -39,9 +30,12 @@ namespace Solver.Tests
         [InlineData("rutaArchivo.txt")]
         public void Leer_ArchivoNoExistente_LanzaArgumentException(string rutaArchivo)
         {
-            _fileSystemHelper.FileExists(rutaArchivo).Returns(false);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(rutaArchivo).Returns(false);
 
-            var ex = Assert.Throws<ArgumentException>(() => _lector.Leer(rutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<ArgumentException>(() => lector.Leer(rutaArchivo));
             Assert.Contains("No existe el archivo", ex.Message);
             Assert.Equal("rutaArchivo", ex.ParamName);
         }
@@ -49,9 +43,13 @@ namespace Solver.Tests
         [Fact]
         public void Leer_ArchivoVacio_LanzaFormatException()
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns([]);
 
-            var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<FormatException>(() => lector.Leer(RutaArchivo));
             Assert.Contains("está vacío o tiene un formato inválido", ex.Message);
         }
 
@@ -61,9 +59,13 @@ namespace Solver.Tests
         [InlineData("1 2 3")]
         public void Leer_PrimeraLineaConFormatoIncorrecto_LanzaFormatException(string primeraLinea)
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
-            var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<FormatException>(() => lector.Leer(RutaArchivo));
             Assert.Contains("debe contener las dimensiones en formato '#filas #columnas'", ex.Message);
         }
 
@@ -73,9 +75,13 @@ namespace Solver.Tests
         [InlineData("Algo 2")]
         public void Leer_CantidadFilasInvalida_LanzaFormatException(string primeraLinea)
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
-            var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<FormatException>(() => lector.Leer(RutaArchivo));
             Assert.Contains("no es numérico", ex.Message);
         }
 
@@ -84,9 +90,13 @@ namespace Solver.Tests
         [InlineData("-1 2")]
         public void Leer_CantidadFilasNoPositiva_LanzaFormatException(string primeraLinea)
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
-            var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<FormatException>(() => lector.Leer(RutaArchivo));
             Assert.Contains("mayor a cero", ex.Message);
         }
 
@@ -95,9 +105,13 @@ namespace Solver.Tests
         [InlineData("2 Algo")]
         public void Leer_CantidadColumnasInvalida_LanzaFormatException(string primeraLinea)
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
-            var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<FormatException>(() => lector.Leer(RutaArchivo));
             Assert.Contains("no es numérico", ex.Message);
         }
 
@@ -106,18 +120,26 @@ namespace Solver.Tests
         [InlineData("2 -1")]
         public void Leer_CantidadColumnasNoPositiva_LanzaFormatException(string primeraLinea)
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns([primeraLinea, "1\t2\t3"]);
 
-            var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<FormatException>(() => lector.Leer(RutaArchivo));
             Assert.Contains("mayor a cero", ex.Message);
         }
 
         [Fact]
         public void Leer_NumeroFilasEsperadasNoCoincideConEncontradas_LanzaFormatException()
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["1 3", "1\t2\t3", "4\t5\t6"]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["1 3", "1\t2\t3", "4\t5\t6"]);
 
-            var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<FormatException>(() => lector.Leer(RutaArchivo));
             Assert.Contains("Filas esperadas", ex.Message);
             Assert.Contains("encontradas", ex.Message);
         }
@@ -129,10 +151,13 @@ namespace Solver.Tests
         public void Leer_NumeroColumnasEsperadasNoCoincideConEncontradas_LanzaFormatException(
             string fila0, string fila1, string fila2, int filaConError, int columnasEncontradas)
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["3 3", fila0, fila1, fila2]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["3 3", fila0, fila1, fila2]);
 
-            var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
 
+            var ex = Assert.Throws<FormatException>(() => lector.Leer(RutaArchivo));
             Assert.Contains($"Fila {filaConError}", ex.Message);
             Assert.Contains("columnas esperadas", ex.Message);
             Assert.Contains($"encontradas: {columnasEncontradas}", ex.Message);
@@ -141,12 +166,15 @@ namespace Solver.Tests
         [Theory]
         [InlineData("@\t2\t3", "4\t5\t6")]
         [InlineData("1\t2\t3", "4\t5\tAlgo")]
-        public void Leer_CeldaConValorInvalido_LanzaFormatException(
-            string fila0, string fila1)
+        public void Leer_CeldaConValorInvalido_LanzaFormatException(string fila0, string fila1)
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["2 3", fila0, fila1]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["2 3", fila0, fila1]);
 
-            var ex = Assert.Throws<FormatException>(() => _lector.Leer(RutaArchivo));
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+
+            var ex = Assert.Throws<FormatException>(() => lector.Leer(RutaArchivo));
             Assert.Contains("Valor inválido", ex.Message);
         }
 
@@ -155,9 +183,12 @@ namespace Solver.Tests
         [InlineData("   4.4\t5.5\t6.6   ")]
         public void Leer_ArchivoValido_NoLanzaExcepciones(string fila1)
         {
-            _fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["2 3", "1.1\t2.2\t3.3", fila1]);
+            var fileSystemHelper = Substitute.For<FileSystemHelper>();
+            fileSystemHelper.FileExists(RutaArchivo).Returns(true);
+            fileSystemHelper.ReadAllLines(RutaArchivo).Returns(["2 3", "1.1\t2.2\t3.3", fila1]);
 
-            decimal[,] matriz = _lector.Leer(RutaArchivo);
+            LectorArchivoMatrizValoraciones lector = ObtenerLectorArchivoMatrizValoraciones(fileSystemHelper);
+            decimal[,] matriz = lector.Leer(RutaArchivo);
 
             Assert.Equal(2, matriz.GetLength(0));
             Assert.Equal(3, matriz.GetLength(1));
@@ -167,6 +198,12 @@ namespace Solver.Tests
             Assert.Equal(4.4m, matriz[1, 0]);
             Assert.Equal(5.5m, matriz[1, 1]);
             Assert.Equal(6.6m, matriz[1, 2]);
+        }
+
+        private LectorArchivoMatrizValoraciones ObtenerLectorArchivoMatrizValoraciones(FileSystemHelper fileSystemHelper)
+        {
+            var lector = new LectorArchivoMatrizValoraciones(fileSystemHelper);
+            return lector;
         }
     }
 }


### PR DESCRIPTION
En este PR se remueven el uso de constructores en clases de tests como método de setup y se reemplaza por métodos que generan las instancias bajo prueba.