### PR TITLE
feat(commands)!: cambio en forma de recibir rutas de archivos a generar y resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cc-cli.exe resolver [opciones]
 
 **Argumentos y opciones**:
 
-| Argumento / Opción       | Descripón                                        | Valores aceptados                                       |
+| Argumento / Opción       | Descripción                                      | Valores aceptados                                       |
 | ------------------------ | ------------------------------------------------ | ------------------------------------------------------- |
 | `ruta-instancia`         | Ruta de la instancia a resolver                  | Un path (**requerido**)                                 |
 | `--limite-generaciones`  | Límite de generaciones a computar (0 = infinito) | Entero positivo (default: 0)                            |

--- a/README.md
+++ b/README.md
@@ -90,16 +90,11 @@ En ese caso se muestra el mejor individuo encontrado hasta el momento.
 cc-cli.exe resolver [opciones]
 ```
 
-**Opciones principales**:
+**Argumentos y opciones**:
 
-| Opción        | Descripción                     | Valores aceptados   |
-| ------------- | ------------------------------- | ------------------- |
-| `--instancia` | Ruta de la instancia a resolver | Un path (requerido) |
-
-**Opciones secundarias**:
-
-| Opción                   | Descripón                                        | Valores aceptados                                       |
+| Argumento / Opción       | Descripón                                        | Valores aceptados                                       |
 | ------------------------ | ------------------------------------------------ | ------------------------------------------------------- |
+| `ruta-instancia`         | Ruta de la instancia a resolver                  | Un path (**requerido**)                                 |
 | `--limite-generaciones`  | Límite de generaciones a computar (0 = infinito) | Entero positivo (default: 0)                            |
 | `--cantidad-individuos`  | Cantidad de individuos por generación            | Entero positivo (default: 100)                          |
 | `--limite-estancamiento` | Límite de generaciones sin mejora (0 = infinito) | Entero positivo (default: 1000)                         |
@@ -108,23 +103,23 @@ cc-cli.exe resolver [opciones]
 **Ejemplos**:
 
 ```bash
-# Resolver una instancia (corre indefinidamente con tamaño de poblacion = 100)
-cc-cli.exe resolver --instancia instancia.dat
+# Resolver una instancia
+cc-cli.exe resolver instancia.dat
 
 # Especificando límite de generaciones
-cc-cli.exe resolver --instancia instancia.dat --limite-generaciones 1000
+cc-cli.exe resolver instancia.dat --limite-generaciones 1000
 
 # Especificando cantidad de individuos
-cc-cli.exe resolver --instancia instancia.dat --cantidad-individuos 500
+cc-cli.exe resolver instancia.dat --cantidad-individuos 500
 
 # Especificando límite de estancamiento
-cc-cli.exe resolver --instancia instancia.dat --limite-estancamiento 500
+cc-cli.exe resolver instancia.dat --limite-estancamiento 500
 
 # Especificando tipo de individuo
-cc-cli.exe resolver --instancia instancia.dat --tipo-individuo optimizacion
+cc-cli.exe resolver instancia.dat --tipo-individuo optimizacion
 
 # Ejemplo completo
-cc-cli.exe resolver --instancia instancia.dat --cantidad-individuos 500 --limite-generaciones 1000 --limite-estancamiento 500 --tipo-individuo intercambio
+cc-cli.exe resolver instancia.dat --limite-generaciones 1000 --cantidad-individuos 500 --limite-estancamiento 500 --tipo-individuo intercambio
 ```
 
 #### 3. Otros comandos

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ decir, que ningún jugador prefiera la porción de otro en vez de la suya.
 ### Uso básico
 
 ```bash
-cc-cli.exe [comando] [opciones]
+cc-cli.exe [comando] [argumentos] [opciones]
 ```
 
 ### Comandos disponibles
@@ -45,23 +45,18 @@ El archivo de salida se sobrescribe sin confirmación.
 **Sintaxis**:
 
 ```bash
-cc-cli.exe generar [opciones]
+cc-cli.exe generar [ruta-salida] [opciones]
 ```
 
-**Opciones principales**:
+**Argumentos y opciones**:
 
-| Opción      | Descripción         | Valores aceptados           |
-| ----------- | ------------------- | --------------------------- |
-| `--atomos`  | Cantidad de átomos  | Entero positivo (requerido) |
-| `--agentes` | Cantidad de agentes | Entero positivo (requerido) |
-
-**Opciones secundarias**:
-
-| Opción           | Descripción                              | Valores aceptados                  |
-| ---------------- | ---------------------------------------- | ---------------------------------- |
-| `--valor-maximo` | Valor máximo para cada valoración        | Entero positivo (default: 1000)    |
-| `--output`       | Ruta donde guardar la instancia generada | Un path (default: `instancia.dat`) |
-| `--disjuntas`    | Indica si las valoraciones son disjuntas |                                    |
+| Argumento / Opción | Descripción                              | Valores aceptados                  |
+| ------------------ | ---------------------------------------- | ---------------------------------- |
+| `ruta-salida`      | Ruta donde guardar la instancia generada | Un path (default: `instancia.dat`) |
+| `--atomos`         | Cantidad de átomos                       | Entero positivo (**requerido**)    |
+| `--agentes`        | Cantidad de agentes                      | Entero positivo (**requerido**)    |
+| `--valor-maximo`   | Valor máximo para cada valoración        | Entero positivo (default: 1000)    |
+| `--disjuntas`      | Indica si las valoraciones son disjuntas | (flag, opcional)                   |
 
 **Ejemplos**:
 
@@ -69,17 +64,17 @@ cc-cli.exe generar [opciones]
 # Instancia básica
 cc-cli.exe generar --atomos 10 --agentes 3
 
-# Con valoraciones disjuntas
-cc-cli.exe generar --atomos 15 --agentes 4 --disjuntas
+# Especificando archivo de salida
+cc-cli.exe generar output/instancia.txt --atomos 8 --agentes 2
 
 # Especificando valor máximo
 cc-cli.exe generar --atomos 8 --agentes 2 --valor-maximo 100
 
-# Especificando archivo de salida
-cc-cli.exe generar --atomos 8 --agentes 2 --output datos/instancia1.txt
+# Con valoraciones disjuntas
+cc-cli.exe generar --atomos 15 --agentes 4 --disjuntas
 
 # Ejemplo completo
-cc-cli.exe generar --atomos 5 --agentes 3 --disjuntas --valor-maximo 500 --output instancia.txt
+cc-cli.exe generar output/instancia.txt --atomos 5 --agentes 3 --valor-maximo 500 --disjuntas
 ```
 
 #### 2. Resolver instancias

--- a/src/App/Commands/Generar/GenerarCommand.cs
+++ b/src/App/Commands/Generar/GenerarCommand.cs
@@ -13,6 +13,10 @@ namespace App.Commands.Generar
         {
             var command = new Command("generar", "Genera una nueva instancia");
 
+            var rutaSalidaArgument = new Argument<string>("ruta-salida", () => RutaSalidaPorDefecto)
+            {
+                Description = "Ruta donde guardar la instancia generada",
+            };
             var atomosOption = new Option<int>("--atomos")
             {
                 Description = "Cantidad de átomos",
@@ -27,29 +31,25 @@ namespace App.Commands.Generar
             {
                 Description = "Valor máximo para cada valoración",
             };
-            var outputOption = new Option<string>("--output", () => RutaSalidaPorDefecto)
-            {
-                Description = "Ruta donde guardar la instancia generada",
-            };
             var disjuntasOption = new Option<bool>("--disjuntas")
             {
                 Description = "Indica si las valoraciones son disjuntas",
             };
 
+            command.AddArgument(rutaSalidaArgument);
             command.AddOption(atomosOption);
             command.AddOption(agentesOption);
             command.AddOption(valorMaximoOption);
-            command.AddOption(outputOption);
             command.AddOption(disjuntasOption);
 
-            command.SetHandler((atomos, agentes, valorMaximo, output, disjuntas) =>
+            command.SetHandler((rutaSalida, atomos, agentes, valorMaximo, disjuntas) =>
             {
                 var parametros = new ParametrosGeneracion
                 {
+                    RutaSalida = rutaSalida,
                     Atomos = atomos,
                     Agentes = agentes,
                     ValorMaximo = valorMaximo,
-                    RutaSalida = output,
                     ValoracionesDisjuntas = disjuntas,
                 };
 
@@ -63,7 +63,7 @@ namespace App.Commands.Generar
                 var presentador = new Presentador(consola);
 
                 EjecutarGeneracion(parametros, builder, escritor, presentador);
-            }, atomosOption, agentesOption, valorMaximoOption, outputOption, disjuntasOption);
+            }, rutaSalidaArgument, atomosOption, agentesOption, valorMaximoOption, disjuntasOption);
 
             return command;
         }

--- a/src/App/Commands/Resolver/ResolverCommand.cs
+++ b/src/App/Commands/Resolver/ResolverCommand.cs
@@ -11,10 +11,10 @@ namespace App.Commands.Resolver
         internal static Command Crear()
         {
             var command = new Command("resolver", "Resuelve una instancia");
-            var instanciaOption = new Option<string>("--instancia")
+
+            var rutaInstanciaArgument = new Argument<string>("ruta-instancia")
             {
                 Description = "Ruta de la instancia a resolver",
-                IsRequired = true,
             };
             var limiteGeneracionesOption = new Option<int>("--limite-generaciones", () => 0)
             {
@@ -33,7 +33,7 @@ namespace App.Commands.Resolver
                 Description = "Tipo de individuo a utilizar (intercambio|optimizacion)",
             };
 
-            command.AddOption(instanciaOption);
+            command.AddArgument(rutaInstanciaArgument);
             command.AddOption(limiteGeneracionesOption);
             command.AddOption(cantidadIndividuosOption);
             command.AddOption(limiteEstancamientoOption);
@@ -63,7 +63,7 @@ namespace App.Commands.Resolver
                 Console.WriteLine("Presioná una tecla para salir...");
                 Console.ReadKey();
 #endif
-            }, instanciaOption, limiteGeneracionesOption, cantidadIndividuosOption, limiteEstancamientoOption, tipoIndividuoOption);
+            }, rutaInstanciaArgument, limiteGeneracionesOption, cantidadIndividuosOption, limiteEstancamientoOption, tipoIndividuoOption);
 
             return command;
         }

--- a/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
+++ b/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
@@ -34,6 +34,28 @@ namespace App.Tests.Commands.Generar
         }
 
         [Fact]
+        public void Crear_AtomosNoEspecificado_IndicaQueEsCampoRequerido()
+        {
+            var comandoGenerar = GenerarCommand.Crear();
+
+            ParseResult resultadoParseo = comandoGenerar.Parse("--agentes 3");
+
+            Assert.Single(resultadoParseo.Errors);
+            Assert.Contains(resultadoParseo.Errors, e => e.Message.Contains("--atomos"));
+        }
+
+        [Fact]
+        public void Crear_AgentesNoEspecificado_IndicaQueEsCampoRequerido()
+        {
+            var comandoGenerar = GenerarCommand.Crear();
+
+            ParseResult resultadoParseo = comandoGenerar.Parse("--atomos 5");
+
+            Assert.Single(resultadoParseo.Errors);
+            Assert.Contains(resultadoParseo.Errors, e => e.Message.Contains("--agentes"));
+        }
+
+        [Fact]
         public void Crear_ValorMaximoNoEspecificado_UsaValorPorDefecto()
         {
             var comandoGenerar = GenerarCommand.Crear();

--- a/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
+++ b/tests/App.Tests/Commands/Generar/GenerarCommandTests.cs
@@ -15,11 +15,22 @@ namespace App.Tests.Commands.Generar
             var comandoGenerar = GenerarCommand.Crear();
 
             Assert.Equal("generar", comandoGenerar.Name);
+            Assert.Contains(comandoGenerar.Arguments, a => a.Name == "ruta-salida");
             Assert.Contains(comandoGenerar.Options, o => o.Name == "atomos");
             Assert.Contains(comandoGenerar.Options, o => o.Name == "agentes");
             Assert.Contains(comandoGenerar.Options, o => o.Name == "valor-maximo");
-            Assert.Contains(comandoGenerar.Options, o => o.Name == "output");
             Assert.Contains(comandoGenerar.Options, o => o.Name == "disjuntas");
+        }
+
+        [Fact]
+        public void Crear_RutaSalidaNoEspecificada_UsaValorPorDefecto()
+        {
+            var comandoGenerar = GenerarCommand.Crear();
+            var rutaSalidaArgument = (Argument<string>)comandoGenerar.Arguments.First(a => a.Name == "ruta-salida");
+
+            string rutaSalida = comandoGenerar.Parse("--atomos 5 --agentes 3").GetValueForArgument(rutaSalidaArgument);
+
+            Assert.Equal(GenerarCommand.RutaSalidaPorDefecto, rutaSalida);
         }
 
         [Fact]
@@ -28,20 +39,9 @@ namespace App.Tests.Commands.Generar
             var comandoGenerar = GenerarCommand.Crear();
             var valorMaximoOption = (Option<int>)comandoGenerar.Options.First(o => o.Name == "valor-maximo");
 
-            int valorMaximo = comandoGenerar.Parse("generar --atomos 5 --agentes 3").GetValueForOption(valorMaximoOption);
+            int valorMaximo = comandoGenerar.Parse("--atomos 5 --agentes 3").GetValueForOption(valorMaximoOption);
 
             Assert.Equal(GenerarCommand.ValorMaximoPorDefecto, valorMaximo);
-        }
-
-        [Fact]
-        public void Crear_OutputNoEspecificada_UsaValorPorDefecto()
-        {
-            var comandoGenerar = GenerarCommand.Crear();
-            var outputOption = (Option<string>)comandoGenerar.Options.First(o => o.Name == "output");
-
-            string output = comandoGenerar.Parse("generar --atomos 5 --agentes 3").GetValueForOption(outputOption);
-
-            Assert.Equal(GenerarCommand.RutaSalidaPorDefecto, output);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace App.Tests.Commands.Generar
             var comandoGenerar = GenerarCommand.Crear();
             var disjuntasOption = (Option<bool>)comandoGenerar.Options.First(o => o.Name == "disjuntas");
 
-            bool disjuntas = comandoGenerar.Parse("generar --atomos 5 --agentes 3").GetValueForOption(disjuntasOption);
+            bool disjuntas = comandoGenerar.Parse("--atomos 5 --agentes 3").GetValueForOption(disjuntasOption);
 
             Assert.False(disjuntas);
         }

--- a/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
+++ b/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine;
+using System.CommandLine.Parsing;
 using App.Commands.Resolver;
 using Common;
 using NSubstitute;
@@ -19,6 +20,16 @@ namespace App.Tests.Commands.Resolver
             Assert.Contains(comandoResolver.Options, o => o.Name == "cantidad-individuos");
             Assert.Contains(comandoResolver.Options, o => o.Name == "limite-estancamiento");
             Assert.Contains(comandoResolver.Options, o => o.Name == "tipo-individuo");
+        }
+
+        [Fact]
+        public void Crear_RutaInstanciaNoEspecificada_IndicaQueEsCampoRequerido()
+        {
+            var comandoResolver = ResolverCommand.Crear();
+
+            ParseResult resultadoParseo = comandoResolver.Parse("");
+
+            Assert.Single(resultadoParseo.Errors);
         }
 
         [Fact]

--- a/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
+++ b/tests/App.Tests/Commands/Resolver/ResolverCommandTests.cs
@@ -14,7 +14,7 @@ namespace App.Tests.Commands.Resolver
             var comandoResolver = ResolverCommand.Crear();
 
             Assert.Equal("resolver", comandoResolver.Name);
-            Assert.Contains(comandoResolver.Options, o => o.Name == "instancia");
+            Assert.Contains(comandoResolver.Arguments, a => a.Name == "ruta-instancia");
             Assert.Contains(comandoResolver.Options, o => o.Name == "limite-generaciones");
             Assert.Contains(comandoResolver.Options, o => o.Name == "cantidad-individuos");
             Assert.Contains(comandoResolver.Options, o => o.Name == "limite-estancamiento");
@@ -27,9 +27,7 @@ namespace App.Tests.Commands.Resolver
             var comandoResolver = ResolverCommand.Crear();
             var limiteGeneracionesOption = (Option<int>)comandoResolver.Options.First(o => o.Name == "limite-generaciones");
 
-            int limiteGeneraciones = comandoResolver
-                .Parse("resolver --instancia instancia.dat")
-                .GetValueForOption(limiteGeneracionesOption);
+            int limiteGeneraciones = comandoResolver.Parse("instancia.dat").GetValueForOption(limiteGeneracionesOption);
 
             Assert.Equal(0, limiteGeneraciones);
         }
@@ -40,9 +38,7 @@ namespace App.Tests.Commands.Resolver
             var comandoResolver = ResolverCommand.Crear();
             var cantidadIndividuosOption = (Option<int>)comandoResolver.Options.First(o => o.Name == "cantidad-individuos");
 
-            int cantidadIndividuos = comandoResolver
-                .Parse("resolver --instancia instancia.dat")
-                .GetValueForOption(cantidadIndividuosOption);
+            int cantidadIndividuos = comandoResolver.Parse("instancia.dat").GetValueForOption(cantidadIndividuosOption);
 
             Assert.Equal(100, cantidadIndividuos);
         }
@@ -53,9 +49,7 @@ namespace App.Tests.Commands.Resolver
             var comandoResolver = ResolverCommand.Crear();
             var limiteEstancamientoOption = (Option<int>)comandoResolver.Options.First(o => o.Name == "limite-estancamiento");
 
-            int limiteEstancamiento = comandoResolver
-                .Parse("resolver --instancia instancia.dat")
-                .GetValueForOption(limiteEstancamientoOption);
+            int limiteEstancamiento = comandoResolver.Parse("instancia.dat").GetValueForOption(limiteEstancamientoOption);
 
             Assert.Equal(1000, limiteEstancamiento);
         }
@@ -66,9 +60,7 @@ namespace App.Tests.Commands.Resolver
             var comandoResolver = ResolverCommand.Crear();
             var tipoIndividuoOption = (Option<string>)comandoResolver.Options.First(o => o.Name == "tipo-individuo");
 
-            string tipoIndividuo = comandoResolver
-                .Parse("resolver --instancia instancia.dat")
-                .GetValueForOption(tipoIndividuoOption);
+            string tipoIndividuo = comandoResolver.Parse("instancia.dat").GetValueForOption(tipoIndividuoOption);
 
             Assert.Equal("intercambio", tipoIndividuo);
         }


### PR DESCRIPTION
En este PR se reemplazaron las opciones `--output` e `--instancia` de los comandos `generar` y `resolver` por argumentos, de manera tal que no se tenga que especificar el nombre de cada uno al indicar su valor.
Se agregaron tests validando los campos requerido de cada comando y se actualizó la documentación.