### PR TITLE
chore(release): sincronización de versionado de release con Directory.Build.props

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+
     - name: Restore dependencies
       run: dotnet restore
+
     - name: Build
       run: dotnet build --no-restore
+
     - name: Test
       run: dotnet test --no-build --verbosity normal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Authors>DerivadaDX</Authors>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <Copyright>Copyright © 2025 DerivadaDX. Licensed under GNU AGPL v3.</Copyright>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
   </PropertyGroup>

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,11 @@ publish:
 	@echo "Listo."
 
 version:
-	npx standard-version --skip.commit=true --skip.tag=true
+	@npx standard-version --skip.commit=true --skip.tag=true
+	@version=$$(sed -n 's:^## \[\([0-9][^]]*\)\].*:\1:p' CHANGELOG.md | head -n 1); \
+	if [ -z "$$version" ]; then \
+		echo "ERROR: no se pudo obtener la nueva versión desde CHANGELOG.md"; \
+		exit 1; \
+	fi; \
+	sed -i 's:<Version>[^<]*</Version>:<Version>'"$$version"'</Version>:' Directory.Build.props; \
+	echo "Version sincronizada en Directory.Build.props: $$version"


### PR DESCRIPTION
En este PR se modificó la regla `vesion` de `Makefile` para que mantenga actualizado el tag `<Version>X.X.X</Version>` de `Directory.Build.props`.
Se separaron los steps de `ci.yml` para verlos mejor.