### PR TITLE
fix(individuos): corrección de error al cruzar cortes-binarios para instancias de matrices cuadradas

### DIFF
--- a/src/Solver/Individuos/IndividuoCortesBinarios.cs
+++ b/src/Solver/Individuos/IndividuoCortesBinarios.cs
@@ -105,6 +105,10 @@ internal class IndividuoCortesBinarios : Individuo
                     indicesConCero.Add(indice);
             }
 
+            bool noHaySwapValido = indicesConUno.Count == 0 || indicesConCero.Count == 0;
+            if (noHaySwapValido)
+                return new IndividuoCortesBinarios(cromosomaHijo, _problema, _generadorRandom);
+
             int indiceUno = _generadorRandom.Siguiente(indicesConUno.Count);
             int posicionUno = indicesConUno[indiceUno];
             cromosomaHijo[posicionUno] = 0;

--- a/src/Solver/Individuos/IndividuoCortesBinarios.cs
+++ b/src/Solver/Individuos/IndividuoCortesBinarios.cs
@@ -203,8 +203,8 @@ internal class IndividuoCortesBinarios : Individuo
                 indicesConCero.Add(indice);
         }
 
-        bool haySwapValido = indicesConUno.Count > 0 && indicesConCero.Count > 0;
-        if (!haySwapValido)
+        bool noHaySwapValido = indicesConCero.Count == 0;
+        if (noHaySwapValido)
             return;
 
         int indiceUno = _generadorRandom.Siguiente(indicesConUno.Count);

--- a/src/Solver/Individuos/IndividuoCortesBinarios.cs
+++ b/src/Solver/Individuos/IndividuoCortesBinarios.cs
@@ -93,8 +93,8 @@ internal class IndividuoCortesBinarios : Individuo
 
         AplicarPoliticaAnticlon(cromosomaHijo, otro);
 
-        var resultado = new IndividuoCortesBinarios(cromosomaHijo, _problema, _generadorRandom);
-        return resultado;
+        var hijo = new IndividuoCortesBinarios(cromosomaHijo, _problema, _generadorRandom);
+        return hijo;
     }
 
     internal override void Mutar()

--- a/src/Solver/Individuos/IndividuoCortesBinarios.cs
+++ b/src/Solver/Individuos/IndividuoCortesBinarios.cs
@@ -91,35 +91,10 @@ internal class IndividuoCortesBinarios : Individuo
             cantidadCortesSeleccionados++;
         }
 
-        bool hijoIgualPadre = cromosomaHijo.SequenceEqual(Cromosoma);
-        bool hijoIgualOtro = cromosomaHijo.SequenceEqual(otro.Cromosoma);
-        if (hijoIgualPadre || hijoIgualOtro)
-        {
-            List<int> indicesConUno = [];
-            List<int> indicesConCero = [];
-            for (int indice = 0; indice < cromosomaHijo.Count; indice++)
-            {
-                if (cromosomaHijo[indice] == 1)
-                    indicesConUno.Add(indice);
-                else
-                    indicesConCero.Add(indice);
-            }
+        AplicarPoliticaAnticlon(cromosomaHijo, otro);
 
-            bool noHaySwapValido = indicesConUno.Count == 0 || indicesConCero.Count == 0;
-            if (noHaySwapValido)
-                return new IndividuoCortesBinarios(cromosomaHijo, _problema, _generadorRandom);
-
-            int indiceUno = _generadorRandom.Siguiente(indicesConUno.Count);
-            int posicionUno = indicesConUno[indiceUno];
-            cromosomaHijo[posicionUno] = 0;
-
-            int indiceCero = _generadorRandom.Siguiente(indicesConCero.Count);
-            int posicionCero = indicesConCero[indiceCero];
-            cromosomaHijo[posicionCero] = 1;
-        }
-
-        var hijo = new IndividuoCortesBinarios(cromosomaHijo, _problema, _generadorRandom);
-        return hijo;
+        var resultado = new IndividuoCortesBinarios(cromosomaHijo, _problema, _generadorRandom);
+        return resultado;
     }
 
     internal override void Mutar()
@@ -208,6 +183,37 @@ internal class IndividuoCortesBinarios : Individuo
         }
 
         return envidiaTotal;
+    }
+
+    private void AplicarPoliticaAnticlon(List<int> cromosomaHijo, IndividuoCortesBinarios otro)
+    {
+        bool hijoIgualPadre = cromosomaHijo.SequenceEqual(Cromosoma);
+        bool hijoIgualOtro = cromosomaHijo.SequenceEqual(otro.Cromosoma);
+        bool hijoNoEsClon = !hijoIgualPadre && !hijoIgualOtro;
+        if (hijoNoEsClon)
+            return;
+
+        List<int> indicesConUno = [];
+        List<int> indicesConCero = [];
+        for (int indice = 0; indice < cromosomaHijo.Count; indice++)
+        {
+            if (cromosomaHijo[indice] == 1)
+                indicesConUno.Add(indice);
+            else
+                indicesConCero.Add(indice);
+        }
+
+        bool haySwapValido = indicesConUno.Count > 0 && indicesConCero.Count > 0;
+        if (!haySwapValido)
+            return;
+
+        int indiceUno = _generadorRandom.Siguiente(indicesConUno.Count);
+        int posicionUno = indicesConUno[indiceUno];
+        cromosomaHijo[posicionUno] = 0;
+
+        int indiceCero = _generadorRandom.Siguiente(indicesConCero.Count);
+        int posicionCero = indicesConCero[indiceCero];
+        cromosomaHijo[posicionCero] = 1;
     }
 
     private List<int> ObtenerPorcionesEnOrdenDeMutacion()

--- a/tests/Solver.Tests/Individuos/IndividuoCortesBinariosTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoCortesBinariosTests.cs
@@ -316,6 +316,25 @@ public class IndividuoCortesBinariosTests : IDisposable
     }
 
     [Fact]
+    public void Cruzar_TodosLosGenesSonCortes_DevuelveUnClonDelPadre()
+    {
+        var problema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,]
+        {
+            { 9m, 1m, 1m, 1m, 1m },
+            { 1m, 9m, 1m, 1m, 1m },
+            { 1m, 1m, 9m, 1m, 1m },
+            { 1m, 1m, 1m, 9m, 1m },
+            { 1m, 1m, 1m, 1m, 9m },
+        });
+        var generador = GeneradorNumerosRandomFactory.Crear(1);
+        var padre = new IndividuoCortesBinarios([1, 1, 1, 1], problema, generador);
+
+        IndividuoCortesBinarios hijo = padre.Cruzar(padre);
+
+        Assert.Equal(padre.Cromosoma, hijo.Cromosoma);
+    }
+
+    [Fact]
     public void Cruzar_Hijo_CalculaAsignacionesYPreferencias()
     {
         List<int> asignacionesEsperadas = [0, 1, 2, 3];


### PR DESCRIPTION
En este PR se corrigió en error que provocaba una excepción al cruzar individuos de la familia `cortes-binarios`.
Se producía al aplicar la política anticlón cuando la instancia a resolver tenía la misma cantidad de agentes y átomos. Ahora se valida si se puede aplicar antes de intentar hacerlo.