### PR TITLE
chore(publish): make publish toma versión de Directory.Build.props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+.codex

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 PROJECT := ./src/App/App.csproj
 OUT := ./src/App/bin/Release/publish
 RIDS := linux-x64 win-x64 win-x86
+VERSION_FILE := ./Directory.Build.props
+VERSION := $(shell sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' $(VERSION_FILE) | head -n 1)
 
 .PHONY: publish version
 
 publish:
+	@if [ ! -f "$(VERSION_FILE)" ]; then \
+		echo "ERROR: no existe $(VERSION_FILE)"; \
+		exit 1; \
+	fi
 	@if [ -z "$(VERSION)" ]; then \
-		echo "ERROR: falta VERSION (ej: make publish VERSION=1.2.3)"; \
+		echo "ERROR: no se pudo obtener <Version> desde $(VERSION_FILE)"; \
 		exit 1; \
 	fi
 	@echo "Publicando versión $(VERSION)"


### PR DESCRIPTION
En este PR se modificó la regla `publish` de `Makefile` para que tome la versión de `./Directory.Build.props`. Todavía permite que se le pase una por línea de comandos.