### PR TITLE
ci(github-actions): se renombró workflow de build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: .NET
+name: Build and Test
 
 on:
   pull_request:


### PR DESCRIPTION
En este PR se renombró el workflow de CI definido en `.github/workflows/ci.yml` para que el nombre visible en GitHub Actions describa mejor lo que hace. Se cambió el nombre de `.NET` a `Build and Test`