### PR TITLE
fix(github-actions): corrección de error al pushear a main en workflow release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,8 +196,12 @@ jobs:
       - name: Push release commit
         if: steps.prepare.outputs.mode == 'normal'
         shell: bash
+        env:
+          PAT_PUSH_MAIN: ${{ secrets.PUSH_MAIN }}
         run: |
           set -euo pipefail
+
+          git remote set-url origin "https://x-access-token:${PAT_PUSH_MAIN}@github.com/DerivadaDX/cc-cli.git"
           git push origin HEAD:main
 
       - name: Create GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,11 +197,11 @@ jobs:
         if: steps.prepare.outputs.mode == 'normal'
         shell: bash
         env:
-          PAT_PUSH_MAIN: ${{ secrets.PUSH_MAIN }}
+          PAT: ${{ secrets.PUSH_MAIN }}
         run: |
           set -euo pipefail
 
-          git remote set-url origin "https://x-access-token:${PAT_PUSH_MAIN}@github.com/DerivadaDX/cc-cli.git"
+          git remote set-url origin "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin HEAD:main
 
       - name: Create GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PUSH_MAIN }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -196,12 +197,8 @@ jobs:
       - name: Push release commit
         if: steps.prepare.outputs.mode == 'normal'
         shell: bash
-        env:
-          PAT: ${{ secrets.PUSH_MAIN }}
         run: |
           set -euo pipefail
-
-          git remote set-url origin "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin HEAD:main
 
       - name: Create GitHub release


### PR DESCRIPTION
En este PR se corrigió el workflow de release para que el step `actions/checkout` use el secreto `PUSH_MAIN` como token y así poder pushear a `main` directamente.