### PR TITLE
feat(solver): se agregó early return cuando la población no admite evolución

### DIFF
--- a/src/Solver/AlgoritmoGenetico.cs
+++ b/src/Solver/AlgoritmoGenetico.cs
@@ -44,8 +44,8 @@ public class AlgoritmoGenetico
     public (Individuo mejorIndividuo, int generaciones) Ejecutar(CancellationToken cancellationToken = default)
     {
         Individuo mejorIndividuo = _poblacion.ObtenerMejorIndividuo();
-        bool mejorIndividuoNoAdmiteEvolucion = !mejorIndividuo.AdmiteEvolucion();
-        if (mejorIndividuoNoAdmiteEvolucion)
+        bool poblacionNoAdmiteEvolucion = !_poblacion.AdmiteEvolucion();
+        if (poblacionNoAdmiteEvolucion)
             return (mejorIndividuo, 0);
 
         decimal mejorFitness = mejorIndividuo.Fitness();

--- a/src/Solver/AlgoritmoGenetico.cs
+++ b/src/Solver/AlgoritmoGenetico.cs
@@ -44,6 +44,10 @@ public class AlgoritmoGenetico
     public (Individuo mejorIndividuo, int generaciones) Ejecutar(CancellationToken cancellationToken = default)
     {
         Individuo mejorIndividuo = _poblacion.ObtenerMejorIndividuo();
+        bool mejorIndividuoNoAdmiteEvolucion = !mejorIndividuo.AdmiteEvolucion();
+        if (mejorIndividuoNoAdmiteEvolucion)
+            return (mejorIndividuo, 0);
+
         decimal mejorFitness = mejorIndividuo.Fitness();
         int ultimaGeneracionConMejora = 0;
         int generacionActual = 0;

--- a/src/Solver/Individuos/Individuo.cs
+++ b/src/Solver/Individuos/Individuo.cs
@@ -32,6 +32,8 @@ public abstract class Individuo
 
     internal abstract decimal Fitness();
 
+    internal abstract bool AdmiteEvolucion();
+
     protected void ValidarCompatibilidadCruce(Individuo otro)
     {
         ArgumentNullException.ThrowIfNull(otro, nameof(otro));

--- a/src/Solver/Individuos/IndividuoCortesBinarios.cs
+++ b/src/Solver/Individuos/IndividuoCortesBinarios.cs
@@ -117,6 +117,12 @@ internal class IndividuoCortesBinarios : Individuo
         return _fitness;
     }
 
+    internal override bool AdmiteEvolucion()
+    {
+        bool hayAlgunCero = Cromosoma.Any(gen => gen == 0);
+        return hayAlgunCero;
+    }
+
     private static void ValidarCromosoma(List<int> cromosoma, InstanciaProblema problema)
     {
         int cantidadGenesEsperada = problema.CantidadAtomos - 1;

--- a/src/Solver/Individuos/IndividuoLegacy.cs
+++ b/src/Solver/Individuos/IndividuoLegacy.cs
@@ -59,6 +59,11 @@ internal abstract class IndividuoLegacy : Individuo
         return fitness;
     }
 
+    internal override bool AdmiteEvolucion()
+    {
+        return true;
+    }
+
     protected abstract void MutarAsignaciones();
 
     protected abstract Individuo CrearNuevoIndividuo(List<int> cromosoma);

--- a/src/Solver/Poblacion.cs
+++ b/src/Solver/Poblacion.cs
@@ -52,6 +52,13 @@ public class Poblacion
         return resultado;
     }
 
+    internal virtual bool AdmiteEvolucion()
+    {
+        Individuo individuoRepresentativo = Individuos[0];
+        bool admiteEvolucion = individuoRepresentativo.AdmiteEvolucion();
+        return admiteEvolucion;
+    }
+
     private List<Individuo> SeleccionarElite()
     {
         // Fracción de la población que se selecciona como individuos élite.

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -221,6 +221,7 @@ public class AlgoritmoGeneticoTests
 
         var poblacion = Substitute.For<Poblacion>(1, Substitute.For<GeneradorNumerosRandom>(1));
         poblacion.ObtenerMejorIndividuo().Returns(individuo);
+        poblacion.AdmiteEvolucion().Returns(true);
 
         return (poblacion, individuo);
     }
@@ -232,6 +233,7 @@ public class AlgoritmoGeneticoTests
 
         var poblacion = Substitute.For<Poblacion>(1, Substitute.For<GeneradorNumerosRandom>(1));
         poblacion.ObtenerMejorIndividuo().Returns(individuo);
+        poblacion.AdmiteEvolucion().Returns(true);
 
         return (poblacion, individuo);
     }
@@ -239,11 +241,12 @@ public class AlgoritmoGeneticoTests
     private static (Poblacion poblacion, Individuo individuo) CrearPoblacionFakeNoEvolutiva()
     {
         Individuo individuo = CrearIndividuoFake();
-        individuo.Fitness().Returns(1);
         individuo.AdmiteEvolucion().Returns(false);
+        individuo.Fitness().Returns(1);
 
         var poblacion = Substitute.For<Poblacion>(1, Substitute.For<GeneradorNumerosRandom>(1));
         poblacion.ObtenerMejorIndividuo().Returns(individuo);
+        poblacion.AdmiteEvolucion().Returns(false);
 
         return (poblacion, individuo);
     }

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -35,6 +35,19 @@ public class AlgoritmoGeneticoTests
     }
 
     [Fact]
+    public void Ejecutar_PoblacionNoAdmiteEvolucion_RetornaMejorIndividuoYCeroGeneraciones()
+    {
+        (Poblacion poblacion, Individuo mejorIndividuo) = CrearPoblacionFakeNoEvolutiva();
+        poblacion.GenerarNuevaGeneracion().Returns(poblacion);
+
+        var algoritmo = new AlgoritmoGenetico(poblacion, limiteGeneraciones: 10, limiteGeneracionesSinMejora: 0);
+        (Individuo mejorIndividuoEncontrado, int generaciones) = algoritmo.Ejecutar();
+
+        Assert.Same(mejorIndividuo, mejorIndividuoEncontrado);
+        Assert.Equal(0, generaciones);
+    }
+
+    [Fact]
     public void Ejecutar_EjecucionCancelada_RetornaMejorIndividuoActual()
     {
         (Poblacion poblacion, Individuo mejorIndividuo) = CrearPoblacionFakeConIndividuoNoOptimo();
@@ -201,19 +214,6 @@ public class AlgoritmoGeneticoTests
         Assert.Equal([1], generacionesNotificadas);
     }
 
-    [Fact]
-    public void Ejecutar_MejorIndividuoNoAdmiteEvolucion_RetornaMejorIndividuoYCeroGeneraciones()
-    {
-        (Poblacion poblacion, Individuo mejorIndividuo) = CrearPoblacionFakeConIndividuoNoEvolutivo();
-        poblacion.GenerarNuevaGeneracion().Returns(poblacion);
-
-        var algoritmo = new AlgoritmoGenetico(poblacion, limiteGeneraciones: 10, limiteGeneracionesSinMejora: 0);
-        (Individuo mejorIndividuoEncontrado, int generaciones) = algoritmo.Ejecutar();
-
-        Assert.Same(mejorIndividuo, mejorIndividuoEncontrado);
-        Assert.Equal(0, generaciones);
-    }
-
     private static (Poblacion poblacion, Individuo individuo) CrearPoblacionFakeConIndividuoNoOptimo()
     {
         Individuo individuo = CrearIndividuoFake();
@@ -236,7 +236,7 @@ public class AlgoritmoGeneticoTests
         return (poblacion, individuo);
     }
 
-    private static (Poblacion poblacion, Individuo individuo) CrearPoblacionFakeConIndividuoNoEvolutivo()
+    private static (Poblacion poblacion, Individuo individuo) CrearPoblacionFakeNoEvolutiva()
     {
         Individuo individuo = CrearIndividuoFake();
         individuo.Fitness().Returns(1);

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -201,6 +201,19 @@ public class AlgoritmoGeneticoTests
         Assert.Equal([1], generacionesNotificadas);
     }
 
+    [Fact]
+    public void Ejecutar_MejorIndividuoNoAdmiteEvolucion_RetornaMejorIndividuoYCeroGeneraciones()
+    {
+        (Poblacion poblacion, Individuo mejorIndividuo) = CrearPoblacionFakeConIndividuoNoEvolutivo();
+        poblacion.GenerarNuevaGeneracion().Returns(poblacion);
+
+        var algoritmo = new AlgoritmoGenetico(poblacion, limiteGeneraciones: 10, limiteGeneracionesSinMejora: 0);
+        (Individuo mejorIndividuoEncontrado, int generaciones) = algoritmo.Ejecutar();
+
+        Assert.Same(mejorIndividuo, mejorIndividuoEncontrado);
+        Assert.Equal(0, generaciones);
+    }
+
     private static (Poblacion poblacion, Individuo individuo) CrearPoblacionFakeConIndividuoNoOptimo()
     {
         Individuo individuo = CrearIndividuoFake();
@@ -223,6 +236,18 @@ public class AlgoritmoGeneticoTests
         return (poblacion, individuo);
     }
 
+    private static (Poblacion poblacion, Individuo individuo) CrearPoblacionFakeConIndividuoNoEvolutivo()
+    {
+        Individuo individuo = CrearIndividuoFake();
+        individuo.Fitness().Returns(1);
+        individuo.AdmiteEvolucion().Returns(false);
+
+        var poblacion = Substitute.For<Poblacion>(1, Substitute.For<GeneradorNumerosRandom>(1));
+        poblacion.ObtenerMejorIndividuo().Returns(individuo);
+
+        return (poblacion, individuo);
+    }
+
     private static Individuo CrearIndividuoFake()
     {
         var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(
@@ -236,6 +261,7 @@ public class AlgoritmoGeneticoTests
         List<int> cromosoma = [1, 1, 2];
         var generadorRandom = Substitute.For<GeneradorNumerosRandom>(1);
         var individuo = Substitute.For<Individuo>(cromosoma, instanciaProblema, generadorRandom);
+        individuo.AdmiteEvolucion().Returns(true);
         return individuo;
     }
 }

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -48,6 +48,22 @@ public class AlgoritmoGeneticoTests
     }
 
     [Fact]
+    public void Ejecutar_PoblacionNoAdmiteEvolucion_NoGeneraNuevaGeneracion()
+    {
+        List<int> generacionesNotificadas = [];
+        (Poblacion poblacion, _) = CrearPoblacionFakeNoEvolutiva();
+        poblacion.GenerarNuevaGeneracion().Returns(poblacion);
+
+        var algoritmo = new AlgoritmoGenetico(poblacion, limiteGeneraciones: 10, limiteGeneracionesSinMejora: 0);
+        algoritmo.GeneracionProcesada += (generacion, _) => generacionesNotificadas.Add(generacion);
+
+        algoritmo.Ejecutar();
+
+        poblacion.DidNotReceive().GenerarNuevaGeneracion();
+        Assert.Empty(generacionesNotificadas);
+    }
+
+    [Fact]
     public void Ejecutar_EjecucionCancelada_RetornaMejorIndividuoActual()
     {
         (Poblacion poblacion, Individuo mejorIndividuo) = CrearPoblacionFakeConIndividuoNoOptimo();

--- a/tests/Solver.Tests/Individuos/IndividuoCortesBinariosTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoCortesBinariosTests.cs
@@ -177,6 +177,22 @@ public class IndividuoCortesBinariosTests : IDisposable
     }
 
     [Fact]
+    public void AdmiteEvolucion_CromosomaTodoUnos_RetornaFalse()
+    {
+        var problema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,]
+        {
+            { 1m, 1m, 1m },
+            { 2m, 2m, 2m },
+            { 3m, 3m, 3m },
+        });
+        IndividuoCortesBinarios individuo = CrearIndividuo([1, 1], problema);
+
+        bool resultado = individuo.AdmiteEvolucion();
+
+        Assert.False(resultado);
+    }
+
+    [Fact]
     public void Fitness_HayEnvidia_RetornaPositivo()
     {
         var problema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(new decimal[,]
@@ -739,6 +755,11 @@ public class IndividuoCortesBinariosTests : IDisposable
         }
 
         internal override decimal Fitness()
+        {
+            throw new NotImplementedException();
+        }
+
+        internal override bool AdmiteEvolucion()
         {
             throw new NotImplementedException();
         }

--- a/tests/Solver.Tests/Individuos/IndividuoLegacyTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoLegacyTests.cs
@@ -544,6 +544,24 @@ public class IndividuoLegacyTests
         Assert.Equal("Cromosoma=[1, 2, 4, 1, 4, 3, 2], Fitness=1.00", resultado);
     }
 
+    [Fact]
+    public void AdmiteEvolucion_IndividuoLegacy_RetornaTrue()
+    {
+        var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(
+            new decimal[,]
+            {
+                { 1m, 0m },
+                { 0m, 1m },
+            }
+        );
+        var generadorRandom = Substitute.For<GeneradorNumerosRandom>(1);
+        var individuo = new IndividuoFake([1, 1, 2], instanciaProblema, generadorRandom);
+
+        bool resultado = individuo.AdmiteEvolucion();
+
+        Assert.True(resultado);
+    }
+
     private sealed class IndividuoFake : IndividuoLegacy
     {
         internal IndividuoFake(List<int> cromosoma, InstanciaProblema problema, GeneradorNumerosRandom generadorRandom)
@@ -588,6 +606,11 @@ public class IndividuoLegacyTests
         }
 
         internal override decimal Fitness()
+        {
+            throw new NotImplementedException();
+        }
+
+        internal override bool AdmiteEvolucion()
         {
             throw new NotImplementedException();
         }

--- a/tests/Solver.Tests/Individuos/IndividuoTests.cs
+++ b/tests/Solver.Tests/Individuos/IndividuoTests.cs
@@ -70,5 +70,10 @@ public class IndividuoTests
         {
             throw new NotImplementedException();
         }
+
+        internal override bool AdmiteEvolucion()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/Solver.Tests/PoblacionTests.cs
+++ b/tests/Solver.Tests/PoblacionTests.cs
@@ -127,7 +127,39 @@ public class PoblacionTests : IDisposable
         Assert.Equal(mejorFitness, mejorIndividuo.Fitness());
     }
 
-    private static Individuo CrearIndividuoFake(int fitness = 0)
+    [Fact]
+    public void AdmiteEvolucion_UnIndividuoNoAdmiteEvolucion_RetornaFalse()
+    {
+        var poblacion = new Poblacion(tamaño: 2, Substitute.For<GeneradorNumerosRandom>(1));
+        poblacion.Individuos.AddRange(
+            [
+                CrearIndividuoFake(admiteEvolucion: false),
+                CrearIndividuoFake(admiteEvolucion: false),
+            ]
+        );
+
+        bool resultado = poblacion.AdmiteEvolucion();
+
+        Assert.False(resultado);
+    }
+
+    [Fact]
+    public void AdmiteEvolucion_UnIndividuoAdmiteEvolucion_RetornaTrue()
+    {
+        var poblacion = new Poblacion(tamaño: 2, Substitute.For<GeneradorNumerosRandom>(1));
+        poblacion.Individuos.AddRange(
+            [
+                CrearIndividuoFake(admiteEvolucion: true),
+                CrearIndividuoFake(admiteEvolucion: true),
+            ]
+        );
+
+        bool resultado = poblacion.AdmiteEvolucion();
+
+        Assert.True(resultado);
+    }
+
+    private static Individuo CrearIndividuoFake(int fitness = 0, bool admiteEvolucion = true)
     {
         List<int> cromosoma = [1, 1, 2];
         var instanciaProblema = InstanciaProblema.CrearDesdeMatrizDeValoraciones(
@@ -144,6 +176,7 @@ public class PoblacionTests : IDisposable
         var otroIndividuo = Substitute.For<Individuo>(cromosoma, instanciaProblema, generadorRandom);
         individuo.Cruzar(Arg.Any<Individuo>()).Returns(otroIndividuo);
         individuo.Fitness().Returns(fitness);
+        individuo.AdmiteEvolucion().Returns(admiteEvolucion);
         return individuo;
     }
 }


### PR DESCRIPTION
En este PR se agregó un early return en `AlgoritmoGenetico` para evitar generar nuevas generaciones cuando la población no admite evolución.

Para eso se incorporó el contrato `AdmiteEvolucion()` en la jerarquía de `Individuo`, se definió su implementación en `IndividuoLegacy` y `IndividuoCortesBinarios`, y se movió la decisión al nivel de `Poblacion` para que el algoritmo genético no dependa de tipos concretos.

Además, se agregaron y ajustaron tests en `Solver.Tests` para cubrir el nuevo comportamiento y validar que, en este caso, no se notifique progreso ni se intente generar una nueva generación.