### PR TITLE
fix(solver): se hace early return si el mejor individuo ya es óptimo

### DIFF
--- a/src/Solver/AlgoritmoGenetico.cs
+++ b/src/Solver/AlgoritmoGenetico.cs
@@ -44,11 +44,15 @@ public class AlgoritmoGenetico
     public (Individuo mejorIndividuo, int generaciones) Ejecutar(CancellationToken cancellationToken = default)
     {
         Individuo mejorIndividuo = _poblacion.ObtenerMejorIndividuo();
+
         bool poblacionNoAdmiteEvolucion = !_poblacion.AdmiteEvolucion();
         if (poblacionNoAdmiteEvolucion)
             return (mejorIndividuo, 0);
 
         decimal mejorFitness = mejorIndividuo.Fitness();
+        if (mejorFitness == 0)
+            return (mejorIndividuo, 0);
+
         int ultimaGeneracionConMejora = 0;
         int generacionActual = 0;
 

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -133,6 +133,24 @@ public class AlgoritmoGeneticoTests
     }
 
     [Fact]
+    public void Ejecutar_MejorIndividuoInicialEsOptimo_HaceEarlyReturn()
+    {
+        List<int> generacionesNotificadas = [];
+        (Poblacion poblacion, Individuo individuoOptimo) = CrearPoblacionFakeConIndividuoOptimo();
+
+        var algoritmo = new AlgoritmoGenetico(poblacion, limiteGeneraciones: 10, limiteGeneracionesSinMejora: 5);
+        algoritmo.GeneracionProcesada += (generacion, _) => generacionesNotificadas.Add(generacion);
+
+        (Individuo mejorIndividuoEncontrado, int generaciones) = algoritmo.Ejecutar();
+
+        Assert.Same(individuoOptimo, mejorIndividuoEncontrado);
+        Assert.Equal(0, generaciones);
+        Assert.Empty(generacionesNotificadas);
+        poblacion.Received(1).ObtenerMejorIndividuo();
+        poblacion.DidNotReceive().GenerarNuevaGeneracion();
+    }
+
+    [Fact]
     public void Ejecutar_HayEstancamiento_NotificaDetencion()
     {
         bool notificado = false;

--- a/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
+++ b/tests/Solver.Tests/AlgoritmoGeneticoTests.cs
@@ -64,6 +64,35 @@ public class AlgoritmoGeneticoTests
     }
 
     [Fact]
+    public void Ejecutar_MejorIndividuoInicialEsOptimo_HaceEarlyReturn()
+    {
+        (Poblacion poblacion, Individuo individuoOptimo) = CrearPoblacionFakeConIndividuoOptimo();
+
+        var algoritmo = new AlgoritmoGenetico(poblacion, limiteGeneraciones: 10, limiteGeneracionesSinMejora: 5);
+
+        (Individuo mejorIndividuoEncontrado, int generaciones) = algoritmo.Ejecutar();
+
+        Assert.Same(individuoOptimo, mejorIndividuoEncontrado);
+        Assert.Equal(0, generaciones);
+        poblacion.Received(1).ObtenerMejorIndividuo();
+    }
+
+    [Fact]
+    public void Ejecutar_MejorIndividuoInicialEsOptimo_NoGeneraNuevaGeneracion()
+    {
+        List<int> generacionesNotificadas = [];
+        (Poblacion poblacion, _) = CrearPoblacionFakeConIndividuoOptimo();
+
+        var algoritmo = new AlgoritmoGenetico(poblacion, limiteGeneraciones: 10, limiteGeneracionesSinMejora: 5);
+        algoritmo.GeneracionProcesada += (generacion, _) => generacionesNotificadas.Add(generacion);
+
+        algoritmo.Ejecutar();
+
+        poblacion.DidNotReceive().GenerarNuevaGeneracion();
+        Assert.Empty(generacionesNotificadas);
+    }
+
+    [Fact]
     public void Ejecutar_EjecucionCancelada_RetornaMejorIndividuoActual()
     {
         (Poblacion poblacion, Individuo mejorIndividuo) = CrearPoblacionFakeConIndividuoNoOptimo();
@@ -129,24 +158,6 @@ public class AlgoritmoGeneticoTests
         var algoritmo = new AlgoritmoGenetico(poblacion, limiteGeneraciones: 0, limiteGeneracionesSinMejora: 0);
         algoritmo.Ejecutar();
 
-        poblacion.DidNotReceive().GenerarNuevaGeneracion();
-    }
-
-    [Fact]
-    public void Ejecutar_MejorIndividuoInicialEsOptimo_HaceEarlyReturn()
-    {
-        List<int> generacionesNotificadas = [];
-        (Poblacion poblacion, Individuo individuoOptimo) = CrearPoblacionFakeConIndividuoOptimo();
-
-        var algoritmo = new AlgoritmoGenetico(poblacion, limiteGeneraciones: 10, limiteGeneracionesSinMejora: 5);
-        algoritmo.GeneracionProcesada += (generacion, _) => generacionesNotificadas.Add(generacion);
-
-        (Individuo mejorIndividuoEncontrado, int generaciones) = algoritmo.Ejecutar();
-
-        Assert.Same(individuoOptimo, mejorIndividuoEncontrado);
-        Assert.Equal(0, generaciones);
-        Assert.Empty(generacionesNotificadas);
-        poblacion.Received(1).ObtenerMejorIndividuo();
         poblacion.DidNotReceive().GenerarNuevaGeneracion();
     }
 


### PR DESCRIPTION
En este PR se agrega un early return en `AlgoritmoGenetico` para cortar la ejecución cuando el mejor individuo inicial ya tiene `Fitness() == 0`.

Con este cambio se evita entrar al loop principal, volver a consultar el mejor individuo y evaluar generación de nuevas poblaciones cuando la solución óptima ya está disponible desde el inicio.