### PR TITLE
ci(release): se mueve release a PR y publicación al merge

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,4 +1,4 @@
-name: Prepare release
+name: Create release PR
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  prepare-release:
+  create-release-pr:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -36,7 +36,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Prepare release context
+      - name: Prepare context
         id: prepare
         env:
           GH_TOKEN: ${{ secrets.PUSH_MAIN }}
@@ -57,8 +57,8 @@ jobs:
             exit 1
           fi
 
-      - name: Version repository
-        id: version
+      - name: Create commit
+        id: release
         shell: bash
         run: |
           set -euo pipefail
@@ -82,25 +82,17 @@ jobs:
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
 
-      - name: Create release commit
-        shell: bash
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
-        run: |
-          set -euo pipefail
-
-          git switch -c "${RELEASE_BRANCH}"
+          git switch -c "${branch}"
           git add package.json package-lock.json Directory.Build.props CHANGELOG.md
-          git commit -m "chore(release): v${RELEASE_VERSION}"
-          git push origin "${RELEASE_BRANCH}"
+          git commit -m "chore(release): v${version}"
+          git push origin "${branch}"
 
-      - name: Create release pull request
+      - name: Create pull request
         id: pr
         env:
           GH_TOKEN: ${{ secrets.PUSH_MAIN }}
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_BRANCH: ${{ steps.release.outputs.branch }}
         shell: bash
         run: |
           set -euo pipefail
@@ -111,14 +103,6 @@ jobs:
             --title "chore(release): v${RELEASE_VERSION}" \
             --body "Release v${RELEASE_VERSION}")"
 
+          gh pr merge "${pr_url}" --auto --squash
+
           echo "url=${pr_url}" >> "${GITHUB_OUTPUT}"
-
-      - name: Enable auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.PUSH_MAIN }}
-          RELEASE_PR: ${{ steps.pr.outputs.url }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          gh pr merge "${RELEASE_PR}" --auto --squash

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,160 @@
+name: Publish release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  publish-release:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'chore/release/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Extract release context
+        id: release
+        env:
+          RELEASE_BRANCH: ${{ github.event.pull_request.head.ref }}
+          RELEASE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_BRANCH}" =~ ^chore/release/v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "La rama ${RELEASE_BRANCH} no cumple el formato chore/release/vX.X.X" >&2
+            exit 1
+          fi
+
+          version="${RELEASE_BRANCH#chore/release/v}"
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "sha=${RELEASE_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Extract release notes
+        id: notes
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${RELEASE_VERSION}"
+          notes_file="${RUNNER_TEMP}/release-notes.md"
+
+          awk -v version="${version}" '
+            $0 ~ "^## \\[" version "\\]" { printing=1 }
+            printing && $0 ~ "^## \\[" && $0 !~ "^## \\[" version "\\]" { exit }
+            printing { print }
+          ' CHANGELOG.md > "${notes_file}"
+
+          if [[ ! -s "${notes_file}" ]]; then
+            echo "No se pudo extraer la sección ${version} de CHANGELOG.md" >&2
+            exit 1
+          fi
+
+          echo "file=${notes_file}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          make publish
+
+      - name: Package assets
+        id: assets
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          version="${RELEASE_VERSION}"
+          publish_root="src/App/bin/Release/publish"
+          shopt -s nullglob
+          matches=("${publish_root}/cc-cli-v${version}-"*)
+          shopt -u nullglob
+
+          if [[ ${#matches[@]} -eq 0 ]]; then
+            echo "No se encontraron directorios publicados para v${version} en ${publish_root}" >&2
+            exit 1
+          fi
+
+          assets=()
+          for dir in "${matches[@]}"; do
+            if [[ ! -d "${dir}" ]]; then
+              continue
+            fi
+
+            base_name="$(basename "${dir}")"
+            zip_path="${RUNNER_TEMP}/${base_name}.zip"
+            rm -f "${zip_path}"
+            (
+              cd "${publish_root}"
+              zip -r "${zip_path}" "${base_name}"
+            )
+            assets+=("${zip_path}")
+          done
+
+          if [[ ${#assets[@]} -eq 0 ]]; then
+            echo "No se pudo generar ningún .zip para v${version}" >&2
+            exit 1
+          fi
+
+          {
+            echo "files<<EOF"
+            printf '%s\n' "${assets[@]}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+          RELEASE_NOTES_FILE: ${{ steps.notes.outputs.file }}
+          RELEASE_ASSETS: ${{ steps.assets.outputs.files }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${RELEASE_VERSION}"
+
+          if gh release view "v${version}" >/dev/null 2>&1; then
+            echo "El release v${version} ya existe" >&2
+            exit 1
+          fi
+
+          mapfile -t assets <<< "${RELEASE_ASSETS}"
+
+          if [[ ${#assets[@]} -eq 0 ]]; then
+            echo "No hay assets para adjuntar al release v${version}" >&2
+            exit 1
+          fi
+
+          gh release create "v${version}" \
+            --target "${RELEASE_SHA}" \
+            --title "v${version}" \
+            --notes-file "${RELEASE_NOTES_FILE}" \
+            "${assets[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,18 @@
-name: Release
+name: Prepare release
 
 on:
   workflow_dispatch:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  release:
+  prepare-release:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,11 +28,6 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-
       - name: Install dependencies
         run: npm ci
 
@@ -43,7 +39,7 @@ jobs:
       - name: Prepare release context
         id: prepare
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PUSH_MAIN }}
         shell: bash
         run: |
           set -euo pipefail
@@ -51,28 +47,6 @@ jobs:
           if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
             echo "Este workflow solo puede ejecutarse sobre refs/heads/main. Ref actual: ${GITHUB_REF}" >&2
             exit 1
-          fi
-
-          head_subject="$(git log -1 --pretty=%s)"
-          release_commit_regex='^chore\(release\): v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'
-          package_version="$(node -p "require('./package.json').version")"
-
-          if [[ "${head_subject}" =~ ${release_commit_regex} ]]; then
-            version="${head_subject#chore(release): v}"
-            if gh release view "v${version}" >/dev/null 2>&1; then
-              echo "El release v${version} ya existe. No hay recuperación pendiente para HEAD." >&2
-              exit 1
-            fi
-
-            if [[ "${package_version}" != "${version}" ]]; then
-              echo "HEAD es un commit de release para v${version}, pero package.json tiene ${package_version}" >&2
-              exit 1
-            fi
-
-            echo "mode=recover" >> "${GITHUB_OUTPUT}"
-            echo "version=${version}" >> "${GITHUB_OUTPUT}"
-            echo "target_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
-            exit 0
           fi
 
           git fetch --tags
@@ -83,11 +57,8 @@ jobs:
             exit 1
           fi
 
-          echo "mode=normal" >> "${GITHUB_OUTPUT}"
-
       - name: Version repository
         id: version
-        if: steps.prepare.outputs.mode == 'normal'
         shell: bash
         run: |
           set -euo pipefail
@@ -101,133 +72,53 @@ jobs:
             exit 1
           fi
 
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          branch="chore/release/v${version}"
 
-      - name: Extract release notes
-        id: notes
-        shell: bash
-        env:
-          RELEASE_VERSION: ${{ steps.prepare.outputs.version || steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          version="${RELEASE_VERSION}"
-          notes_file="${RUNNER_TEMP}/release-notes.md"
-
-          awk -v version="${version}" '
-            $0 ~ "^## \\[" version "\\]" { printing=1 }
-            printing && $0 ~ "^## \\[" && $0 !~ "^## \\[" version "\\]" { exit }
-            printing { print }
-          ' CHANGELOG.md > "${notes_file}"
-
-          if [[ ! -s "${notes_file}" ]]; then
-            echo "No se pudo extraer la sección ${version} de CHANGELOG.md" >&2
+          if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+            echo "La rama ${branch} ya existe en origin" >&2
             exit 1
           fi
 
-          echo "file=${notes_file}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
 
       - name: Create release commit
-        id: commit
-        if: steps.prepare.outputs.mode == 'normal'
         shell: bash
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
         run: |
           set -euo pipefail
 
-          version="${RELEASE_VERSION}"
+          git switch -c "${RELEASE_BRANCH}"
           git add package.json package-lock.json Directory.Build.props CHANGELOG.md
-          git commit -m "chore(release): v${version}"
+          git commit -m "chore(release): v${RELEASE_VERSION}"
+          git push origin "${RELEASE_BRANCH}"
 
-          echo "target_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
-
-      - name: Publish binaries
-        shell: bash
-        run: |
-          set -euo pipefail
-          make publish
-
-      - name: Package assets
-        id: assets
-        shell: bash
+      - name: Create release pull request
+        id: pr
         env:
-          RELEASE_VERSION: ${{ steps.prepare.outputs.version || steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          version="${RELEASE_VERSION}"
-          publish_root="src/App/bin/Release/publish"
-          shopt -s nullglob
-          matches=("${publish_root}/cc-cli-v${version}-"*)
-          shopt -u nullglob
-
-          if [[ ${#matches[@]} -eq 0 ]]; then
-            echo "No se encontraron directorios publicados para v${version} en ${publish_root}" >&2
-            exit 1
-          fi
-
-          assets=()
-          for dir in "${matches[@]}"; do
-            if [[ ! -d "${dir}" ]]; then
-              continue
-            fi
-
-            base_name="$(basename "${dir}")"
-            zip_path="${RUNNER_TEMP}/${base_name}.zip"
-            rm -f "${zip_path}"
-            (
-              cd "${publish_root}"
-              zip -r "${zip_path}" "${base_name}"
-            )
-            assets+=("${zip_path}")
-          done
-
-          if [[ ${#assets[@]} -eq 0 ]]; then
-            echo "No se pudo generar ningún .zip para v${version}" >&2
-            exit 1
-          fi
-
-          {
-            echo "files<<EOF"
-            printf '%s\n' "${assets[@]}"
-            echo "EOF"
-          } >> "${GITHUB_OUTPUT}"
-
-      - name: Push release commit
-        if: steps.prepare.outputs.mode == 'normal'
+          GH_TOKEN: ${{ secrets.PUSH_MAIN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
         shell: bash
         run: |
           set -euo pipefail
-          git push origin HEAD:main
 
-      - name: Create GitHub release
-        shell: bash
+          pr_url="$(gh pr create \
+            --base main \
+            --head "${RELEASE_BRANCH}" \
+            --title "chore(release): v${RELEASE_VERSION}" \
+            --body "Release v${RELEASE_VERSION}")"
+
+          echo "url=${pr_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ steps.prepare.outputs.version || steps.version.outputs.version }}
-          RELEASE_SHA: ${{ steps.prepare.outputs.target_sha || steps.commit.outputs.target_sha }}
-          RELEASE_NOTES_FILE: ${{ steps.notes.outputs.file }}
-          RELEASE_ASSETS: ${{ steps.assets.outputs.files }}
+          GH_TOKEN: ${{ secrets.PUSH_MAIN }}
+          RELEASE_PR: ${{ steps.pr.outputs.url }}
+        shell: bash
         run: |
           set -euo pipefail
 
-          version="${RELEASE_VERSION}"
-
-          if gh release view "v${version}" >/dev/null 2>&1; then
-            echo "El release v${version} ya existe" >&2
-            exit 1
-          fi
-
-          mapfile -t assets <<< "${RELEASE_ASSETS}"
-
-          if [[ ${#assets[@]} -eq 0 ]]; then
-            echo "No hay assets para adjuntar al release v${version}" >&2
-            exit 1
-          fi
-
-          gh release create "v${version}" \
-            --target "${RELEASE_SHA}" \
-            --title "v${version}" \
-            --notes-file "${RELEASE_NOTES_FILE}" \
-            "${assets[@]}"
+          gh pr merge "${RELEASE_PR}" --auto --squash


### PR DESCRIPTION
En este PR se separó el workflow de release en dos partes: `create-release-pr.yml` prepara la versión, crea la rama `chore/release/vX.X.X`, abre el PR contra `main` y activa auto-merge; `publish-release.yml` escucha el merge de ese PR y recién entonces publica el release con sus assets.

Con este cambio, el commit de release pasa por el mismo flujo de PR y validaciones que el resto de los cambios, y la publicación queda atada al merge efectivo en `main` en lugar de ejecutarse antes de que el release entre a la rama principal.